### PR TITLE
chore: add changeset for type fix and null sanitization

### DIFF
--- a/.changeset/fix-type-errors-null-sanitization.md
+++ b/.changeset/fix-type-errors-null-sanitization.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/agent": patch
+---
+
+Fix type errors in test mocks, add null→undefined sanitization in applyNextTurnParamsToRequest, and release-gate publishing via workflow_dispatch


### PR DESCRIPTION
## Summary

Adds a `patch` changeset for the changes merged in #3 (type error fixes, null→undefined sanitization in `applyNextTurnParamsToRequest`, release-gated publishing, changeset skill docs). This changeset was missing from the original PR.

## Review & Testing Checklist for Human

- [ ] Verify `patch` is the correct bump level — the changes were bug fixes and defensive coding (no new features or breaking changes), so `patch` should be appropriate
- [ ] After merging, run the Release workflow with **mode: version** from the Actions tab to consume this changeset and create a Version Packages PR

### Notes
- This is just a changeset file — no functional code changes

Link to Devin session: https://app.devin.ai/sessions/7690662a430848d9be47c3b020fdb50f
Requested by: @robert-j-y