### PR TITLE
fix(sdk): yield manual tool calls from getNewMessagesStream()

### DIFF
--- a/src/lib/model-result.ts
+++ b/src/lib/model-result.ts
@@ -577,14 +577,6 @@ export class ModelResult<
     return !!tool && !hasExecuteFunction(tool);
   }
 
-  private *yieldManualToolCalls(response: models.OpenResponsesResult): Generator<models.OutputFunctionCallItem> {
-    for (const item of response.output) {
-      if (isFunctionCallItem(item) && this.isManualToolCall(item)) {
-        yield item;
-      }
-    }
-  }
-
   /**
    * Execute tools that can auto-execute (don't require approval) in parallel.
    *
@@ -1683,11 +1675,15 @@ export class ModelResult<
       // Execute tools if needed
       await this.executeToolsIfNeeded();
 
+      // Track yielded call IDs to avoid duplicates across rounds and finalResponse
+      const yieldedCallIds = new Set<string>();
+
       // Yield function calls and their outputs for each executed tool
       for (const round of this.allToolExecutionRounds) {
         // First yield the function_call items from the response that triggered tool execution
         for (const item of round.response.output) {
           if (isFunctionCallItem(item)) {
+            yieldedCallIds.add(item.callId);
             yield item;
           }
         }
@@ -1697,9 +1693,14 @@ export class ModelResult<
         }
       }
 
-      // Yield manual tool function_call items from finalResponse
+      // Yield manual tool function_call items from finalResponse, skipping duplicates
       if (this.finalResponse) {
-        yield* this.yieldManualToolCalls(this.finalResponse);
+        for (const item of this.finalResponse.output) {
+          if (isFunctionCallItem(item) && this.isManualToolCall(item) && !yieldedCallIds.has(item.callId)) {
+            yieldedCallIds.add(item.callId);
+            yield item;
+          }
+        }
       }
 
       // If tools were executed, yield the final message from finalResponse

--- a/src/lib/model-result.ts
+++ b/src/lib/model-result.ts
@@ -572,6 +572,19 @@ export class ModelResult<
     });
   }
 
+  private isManualToolCall(item: models.OutputFunctionCallItem): boolean {
+    const tool = this.options.tools?.find((t) => t.function.name === item.name);
+    return !!tool && !hasExecuteFunction(tool);
+  }
+
+  private *yieldManualToolCalls(response: models.OpenResponsesResult): Generator<models.OutputFunctionCallItem> {
+    for (const item of response.output) {
+      if (isFunctionCallItem(item) && this.isManualToolCall(item)) {
+        yield item;
+      }
+    }
+  }
+
   /**
    * Execute tools that can auto-execute (don't require approval) in parallel.
    *
@@ -1684,9 +1697,13 @@ export class ModelResult<
         }
       }
 
-      // If tools were executed, yield the final message (if there is one)
+      // Yield manual tool function_call items from finalResponse
+      if (this.finalResponse) {
+        yield* this.yieldManualToolCalls(this.finalResponse);
+      }
+
+      // If tools were executed, yield the final message from finalResponse
       if (this.finalResponse && this.allToolExecutionRounds.length > 0) {
-        // Check if the final response contains a message
         const hasMessage = this.finalResponse.output.some(
           (item: unknown) => hasTypeProperty(item) && item.type === 'message',
         );

--- a/tests/e2e/call-model.test.ts
+++ b/tests/e2e/call-model.test.ts
@@ -1,5 +1,6 @@
 import type { ClaudeMessageParam } from '@openrouter/sdk/models/claude-message';
 import type { OpenResponsesFunctionCallOutput } from '@openrouter/sdk/models/openresponsesfunctioncalloutput';
+import type { OutputFunctionCallItem } from '@openrouter/sdk/models/outputfunctioncallitem';
 import type { ResponsesOutputMessage } from '@openrouter/sdk/models/responsesoutputmessage';
 import type { ChatStreamEvent, ResponseStreamEvent } from '../../src/lib/tool-types.js';
 
@@ -153,7 +154,7 @@ describe('callModel E2E Tests', () => {
                 condition: z.string(),
               }),
               // Don't auto-execute so we can test getToolCalls()
-              execute: false,
+              // No execute function — manual tool
             },
           },
         ],
@@ -768,6 +769,123 @@ describe('callModel E2E Tests', () => {
         }
       }
     }, 15000);
+
+    it('should yield function_call items for manual tools after auto-execute rounds', async () => {
+      const response = client.callModel({
+        model: 'anthropic/claude-sonnet-4.5',
+        instructions:
+          'You have two tools. First call get_weather to get the weather, then call submit_report with a summary. Always call both tools.',
+        input: fromChatMessages([
+          {
+            role: 'user',
+            content: "What's the weather in Tokyo? Get the weather and then submit a report.",
+          },
+        ]),
+        toolChoice: 'required',
+        stopWhen: stepCountIs(2),
+        tools: [
+          {
+            type: ToolType.Function,
+            function: {
+              name: 'get_weather',
+              description: 'Get weather for a location. Always call this first.',
+              inputSchema: z.object({
+                location: z.string().describe('City name'),
+              }),
+              outputSchema: z.object({
+                temperature: z.number(),
+                condition: z.string(),
+              }),
+              execute: async (params) => ({
+                temperature: 22,
+                condition: 'Sunny in ' + params.location,
+              }),
+            },
+          },
+          {
+            type: ToolType.Function,
+            function: {
+              name: 'submit_report',
+              description: 'Submit a weather report summary. Call this after get_weather.',
+              inputSchema: z.object({
+                summary: z.string().describe('Weather summary'),
+              }),
+              outputSchema: z.object({
+                success: z.boolean(),
+              }),
+              // No execute function — manual tool
+            },
+          },
+        ],
+      });
+
+      const items: (ResponsesOutputMessage | OpenResponsesFunctionCallOutput | OutputFunctionCallItem)[] = [];
+
+      for await (const item of response.getNewMessagesStream()) {
+        items.push(item);
+      }
+
+      const functionCallItems = items.filter((i) => i.type === 'function_call');
+      const functionCallOutputItems = items.filter((i) => i.type === 'function_call_output');
+
+      // Auto-executed tool should produce function_call_output
+      expect(functionCallOutputItems.length).toBeGreaterThan(0);
+
+      // Manual tool (submit_report) should appear as a function_call item
+      // This is the bug fix: previously these were silently dropped
+      const manualToolCall = functionCallItems.find(
+        (i) => 'name' in i && i.name === 'submit_report',
+      );
+      expect(manualToolCall).toBeDefined();
+      expect(manualToolCall!.type).toBe('function_call');
+      expect(manualToolCall!).toHaveProperty('arguments');
+    }, 60000);
+
+    it('should yield function_call items when only manual tools are present (no auto-execute)', async () => {
+      const response = client.callModel({
+        model: 'anthropic/claude-sonnet-4.5',
+        instructions: 'You must call the submit_report tool with a brief weather summary.',
+        input: fromChatMessages([
+          {
+            role: 'user',
+            content: 'Submit a weather report for Tokyo saying it is sunny and 22 degrees.',
+          },
+        ]),
+        toolChoice: 'required',
+        tools: [
+          {
+            type: ToolType.Function,
+            function: {
+              name: 'submit_report',
+              description: 'Submit a weather report summary.',
+              inputSchema: z.object({
+                summary: z.string().describe('Weather summary'),
+              }),
+              outputSchema: z.object({
+                success: z.boolean(),
+              }),
+              // No execute function — manual tool
+            },
+          },
+        ],
+      });
+
+      const items: (ResponsesOutputMessage | OpenResponsesFunctionCallOutput | OutputFunctionCallItem)[] = [];
+
+      for await (const item of response.getNewMessagesStream()) {
+        items.push(item);
+      }
+
+      const functionCallItems = items.filter((i) => i.type === 'function_call');
+
+      // Manual tool (submit_report) should appear as a function_call item
+      const manualToolCall = functionCallItems.find(
+        (i) => 'name' in i && i.name === 'submit_report',
+      );
+      expect(manualToolCall).toBeDefined();
+      expect(manualToolCall!.type).toBe('function_call');
+      expect(manualToolCall!).toHaveProperty('arguments');
+    }, 60000);
   });
 
   describe('response.reasoningStream - Streaming reasoning deltas', () => {

--- a/tests/unit/get-items-stream-manual-tools.test.ts
+++ b/tests/unit/get-items-stream-manual-tools.test.ts
@@ -1,0 +1,202 @@
+import type {
+  OpenResponsesStreamEvent,
+  OpenResponsesStreamEventResponseCompleted,
+  OpenResponsesStreamEventResponseFunctionCallArgumentsDelta,
+  OpenResponsesStreamEventResponseFunctionCallArgumentsDone,
+  OpenResponsesStreamEventResponseOutputItemAdded,
+  OpenResponsesStreamEventResponseOutputItemDone,
+} from '@openrouter/sdk/models/openresponsesstreamevent';
+import type { OutputFunctionCallItem } from '@openrouter/sdk/models/outputfunctioncallitem';
+import type { OpenRouterCore } from '@openrouter/sdk/core';
+import type { StreamableOutputItem } from '../../src/lib/stream-transformers.js';
+
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { ReusableReadableStream } from '../../src/lib/reusable-stream.js';
+import { ModelResult } from '../../src/lib/model-result.js';
+import { ToolType } from '../../src/lib/tool-types.js';
+import { isFunctionCallItem } from '../../src/lib/stream-type-guards.js';
+
+// ============================================================================
+// Synthetic event factories
+// ============================================================================
+
+function createImmediateStream(
+  events: OpenResponsesStreamEvent[],
+): ReusableReadableStream<OpenResponsesStreamEvent> {
+  const readable = new ReadableStream<OpenResponsesStreamEvent>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(event);
+      }
+      controller.close();
+    },
+  });
+  return new ReusableReadableStream(readable);
+}
+
+function outputItemAddedFunctionCallEvent(
+  callId: string,
+  name: string,
+  itemId: string,
+): OpenResponsesStreamEventResponseOutputItemAdded {
+  return {
+    type: 'response.output_item.added',
+    outputIndex: 0,
+    item: {
+      type: 'function_call',
+      id: itemId,
+      callId,
+      name,
+      arguments: '',
+      status: 'in_progress',
+    },
+    sequenceNumber: 0,
+  };
+}
+
+function functionCallArgsDeltaEvent(
+  delta: string,
+  itemId: string,
+): OpenResponsesStreamEventResponseFunctionCallArgumentsDelta {
+  return {
+    type: 'response.function_call_arguments.delta',
+    itemId,
+    outputIndex: 0,
+    delta,
+    sequenceNumber: 0,
+  };
+}
+
+function functionCallArgsDoneEvent(
+  args: string,
+  name: string,
+  itemId: string,
+): OpenResponsesStreamEventResponseFunctionCallArgumentsDone {
+  return {
+    type: 'response.function_call_arguments.done',
+    itemId,
+    outputIndex: 0,
+    name,
+    arguments: args,
+    sequenceNumber: 0,
+  };
+}
+
+function outputItemDoneFunctionCallEvent(
+  callId: string,
+  name: string,
+  args: string,
+  itemId: string,
+): OpenResponsesStreamEventResponseOutputItemDone {
+  return {
+    type: 'response.output_item.done',
+    outputIndex: 0,
+    item: {
+      type: 'function_call',
+      id: itemId,
+      callId,
+      name,
+      arguments: args,
+      status: 'completed',
+    },
+    sequenceNumber: 0,
+  };
+}
+
+function responseCompletedEvent(
+  functionCallItem: OutputFunctionCallItem,
+): OpenResponsesStreamEventResponseCompleted {
+  return {
+    type: 'response.completed',
+    response: {
+      id: 'resp_test_1',
+      object: 'response',
+      createdAt: 0,
+      model: 'test-model',
+      status: 'completed',
+      completedAt: 0,
+      output: [functionCallItem],
+      error: null,
+      incompleteDetails: null,
+      temperature: null,
+      topP: null,
+      presencePenalty: null,
+      frequencyPenalty: null,
+      metadata: null,
+      instructions: null,
+      tools: [],
+      toolChoice: 'auto',
+      parallelToolCalls: false,
+    },
+    sequenceNumber: 0,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('getItemsStream with manual tools — duplicate detection', () => {
+  const CALL_ID = 'call_test_1';
+  const ITEM_ID = 'fc_test_1';
+  const TOOL_NAME = 'submit_report';
+  const ARGS = '{"summary":"Tokyo weather is sunny"}';
+
+  const completedFunctionCallItem: OutputFunctionCallItem = {
+    type: 'function_call',
+    id: ITEM_ID,
+    callId: CALL_ID,
+    name: TOOL_NAME,
+    arguments: ARGS,
+    status: 'completed',
+  };
+
+  const streamEvents: OpenResponsesStreamEvent[] = [
+    outputItemAddedFunctionCallEvent(CALL_ID, TOOL_NAME, ITEM_ID),
+    functionCallArgsDeltaEvent('{"summary":', ITEM_ID),
+    functionCallArgsDeltaEvent('"Tokyo weather is sunny"}', ITEM_ID),
+    functionCallArgsDoneEvent(ARGS, TOOL_NAME, ITEM_ID),
+    outputItemDoneFunctionCallEvent(CALL_ID, TOOL_NAME, ARGS, ITEM_ID),
+    responseCompletedEvent(completedFunctionCallItem),
+  ];
+
+  it('should not yield duplicate function_call items when only manual tools are present', async () => {
+    const manualTool = {
+      type: ToolType.Function,
+      function: {
+        name: TOOL_NAME,
+        description: 'Submit a weather report summary.',
+        inputSchema: z.object({ summary: z.string() }),
+        outputSchema: z.object({ success: z.boolean() }),
+      },
+    } as const;
+
+    const modelResult = new ModelResult({
+      request: { model: 'test-model', input: 'test' },
+      client: {} as unknown as OpenRouterCore,
+      tools: [manualTool],
+    });
+
+    // Bypass initStream by directly setting private fields.
+    // Double-cast required to access private properties for test setup.
+    const internal = modelResult as unknown as Record<string, unknown>;
+    internal['reusableStream'] = createImmediateStream(streamEvents);
+    internal['initPromise'] = Promise.resolve();
+
+    // Consume getItemsStream and collect all items
+    const items: StreamableOutputItem[] = [];
+    for await (const item of modelResult.getItemsStream()) {
+      items.push(item);
+    }
+
+    // Filter to completed function_call items only
+    const completedFunctionCalls = items.filter(
+      (item) => isFunctionCallItem(item) && item.status === 'completed',
+    );
+
+    // If the bug exists, this will be 2 (once from buildItemsStream, once from yieldManualToolCalls).
+    // Correct behavior: exactly 1 completed function_call per tool call.
+    expect(completedFunctionCalls).toHaveLength(1);
+  });
+});

--- a/tests/unit/manual-tool-calls-adversarial.test.ts
+++ b/tests/unit/manual-tool-calls-adversarial.test.ts
@@ -280,15 +280,8 @@ describe('manual tool calls — adversarial edge cases', () => {
           (i as OutputFunctionCallItem).name === 'submit',
       );
 
-      // BUG DETECTOR: if the dedup is missing, this would be 2.
-      // The current PR code DOES NOT dedup — it yields from rounds AND from
-      // yieldManualToolCalls unconditionally. This test documents the exposure.
-      // If the count is > 1 the consumer sees the same tool call twice.
-      expect(manualCalls.length).toBeGreaterThanOrEqual(1);
-
-      // Ideally this should be exactly 1. The test below is stricter:
-      // Uncomment when dedup is added:
-      // expect(manualCalls).toHaveLength(1);
+      // With callId-based dedup, the manual tool call should appear exactly once
+      expect(manualCalls).toHaveLength(1);
     });
 
     it('should yield manual tool calls from finalResponse when no rounds executed (pure manual scenario)', async () => {

--- a/tests/unit/manual-tool-calls-adversarial.test.ts
+++ b/tests/unit/manual-tool-calls-adversarial.test.ts
@@ -1,0 +1,731 @@
+import type {
+  OpenResponsesStreamEvent,
+  OpenResponsesStreamEventResponseCompleted,
+  OpenResponsesStreamEventResponseFunctionCallArgumentsDelta,
+  OpenResponsesStreamEventResponseFunctionCallArgumentsDone,
+  OpenResponsesStreamEventResponseOutputItemAdded,
+  OpenResponsesStreamEventResponseOutputItemDone,
+} from '@openrouter/sdk/models/openresponsesstreamevent';
+import type { OutputFunctionCallItem } from '@openrouter/sdk/models/outputfunctioncallitem';
+import type { OpenRouterCore } from '@openrouter/sdk/core';
+import type { StreamableOutputItem } from '../../src/lib/stream-transformers.js';
+import type { OpenResponsesResult } from '@openrouter/sdk/models/openresponsesresult';
+
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { ReusableReadableStream } from '../../src/lib/reusable-stream.js';
+import { ModelResult } from '../../src/lib/model-result.js';
+import { ToolType } from '../../src/lib/tool-types.js';
+import { isFunctionCallItem } from '../../src/lib/stream-type-guards.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createImmediateStream(
+  events: OpenResponsesStreamEvent[],
+): ReusableReadableStream<OpenResponsesStreamEvent> {
+  const readable = new ReadableStream<OpenResponsesStreamEvent>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(event);
+      }
+      controller.close();
+    },
+  });
+  return new ReusableReadableStream(readable);
+}
+
+function makeFunctionCallItem(
+  callId: string,
+  name: string,
+  args: string,
+  itemId: string,
+  status: 'completed' | 'in_progress' = 'completed',
+): OutputFunctionCallItem {
+  return { type: 'function_call', id: itemId, callId, name, arguments: args, status };
+}
+
+function outputItemAddedEvent(
+  callId: string,
+  name: string,
+  itemId: string,
+): OpenResponsesStreamEventResponseOutputItemAdded {
+  return {
+    type: 'response.output_item.added',
+    outputIndex: 0,
+    item: { type: 'function_call', id: itemId, callId, name, arguments: '', status: 'in_progress' },
+    sequenceNumber: 0,
+  };
+}
+
+function argsDeltaEvent(
+  delta: string,
+  itemId: string,
+): OpenResponsesStreamEventResponseFunctionCallArgumentsDelta {
+  return {
+    type: 'response.function_call_arguments.delta',
+    itemId,
+    outputIndex: 0,
+    delta,
+    sequenceNumber: 0,
+  };
+}
+
+function argsDoneEvent(
+  args: string,
+  name: string,
+  itemId: string,
+): OpenResponsesStreamEventResponseFunctionCallArgumentsDone {
+  return {
+    type: 'response.function_call_arguments.done',
+    itemId,
+    outputIndex: 0,
+    name,
+    arguments: args,
+    sequenceNumber: 0,
+  };
+}
+
+function outputItemDoneEvent(
+  callId: string,
+  name: string,
+  args: string,
+  itemId: string,
+): OpenResponsesStreamEventResponseOutputItemDone {
+  return {
+    type: 'response.output_item.done',
+    outputIndex: 0,
+    item: { type: 'function_call', id: itemId, callId, name, arguments: args, status: 'completed' },
+    sequenceNumber: 0,
+  };
+}
+
+function responseCompletedEvent(
+  output: OpenResponsesResult['output'],
+): OpenResponsesStreamEventResponseCompleted {
+  return {
+    type: 'response.completed',
+    response: {
+      id: 'resp_test',
+      object: 'response',
+      createdAt: 0,
+      model: 'test-model',
+      status: 'completed',
+      completedAt: 0,
+      output,
+      error: null,
+      incompleteDetails: null,
+      temperature: null,
+      topP: null,
+      presencePenalty: null,
+      frequencyPenalty: null,
+      metadata: null,
+      instructions: null,
+      tools: [],
+      toolChoice: 'auto',
+      parallelToolCalls: false,
+    },
+    sequenceNumber: 0,
+  };
+}
+
+function makeResponse(output: OpenResponsesResult['output']): OpenResponsesResult {
+  return {
+    id: 'resp_test',
+    object: 'response',
+    createdAt: 0,
+    model: 'test-model',
+    status: 'completed',
+    completedAt: 0,
+    output,
+    error: null,
+    incompleteDetails: null,
+    temperature: null,
+    topP: null,
+    presencePenalty: null,
+    frequencyPenalty: null,
+    metadata: null,
+    instructions: null,
+    tools: [],
+    toolChoice: 'auto',
+    parallelToolCalls: false,
+  };
+}
+
+function manualTool(name: string) {
+  return {
+    type: ToolType.Function,
+    function: {
+      name,
+      description: `Manual tool: ${name}`,
+      inputSchema: z.object({ data: z.string() }),
+      outputSchema: z.object({ ok: z.boolean() }),
+    },
+  } as const;
+}
+
+function autoTool(name: string) {
+  return {
+    type: ToolType.Function,
+    function: {
+      name,
+      description: `Auto tool: ${name}`,
+      inputSchema: z.object({ data: z.string() }),
+      outputSchema: z.object({ ok: z.boolean() }),
+      execute: async () => ({ ok: true }),
+    },
+  } as const;
+}
+
+type InternalModelResult = Record<string, unknown>;
+
+function setupModelResult(
+  tools: readonly ReturnType<typeof manualTool | typeof autoTool>[],
+  events: OpenResponsesStreamEvent[],
+  overrides?: {
+    finalResponse?: OpenResponsesResult | null;
+    allToolExecutionRounds?: Array<{
+      round: number;
+      toolCalls: Array<{ id: string; name: string; arguments: string }>;
+      response: OpenResponsesResult;
+      toolResults: Array<{ type: 'function_call_output'; callId: string; output: string }>;
+    }>;
+  },
+) {
+  const modelResult = new ModelResult({
+    request: { model: 'test-model', input: 'test' },
+    client: {} as unknown as OpenRouterCore,
+    tools,
+  });
+
+  const internal = modelResult as unknown as InternalModelResult;
+  internal['reusableStream'] = createImmediateStream(events);
+  internal['initPromise'] = Promise.resolve();
+
+  if (overrides?.finalResponse !== undefined) {
+    internal['finalResponse'] = overrides.finalResponse;
+  }
+  if (overrides?.allToolExecutionRounds) {
+    internal['allToolExecutionRounds'] = overrides.allToolExecutionRounds;
+    // Prevent executeToolsIfNeeded from running the actual tool execution loop
+    internal['toolExecutionPromise'] = Promise.resolve();
+  }
+
+  return modelResult;
+}
+
+function streamEventsForToolCall(callId: string, name: string, args: string, itemId: string) {
+  return [
+    outputItemAddedEvent(callId, name, itemId),
+    argsDeltaEvent(args, itemId),
+    argsDoneEvent(args, name, itemId),
+    outputItemDoneEvent(callId, name, args, itemId),
+  ];
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('manual tool calls — adversarial edge cases', () => {
+  // -------------------------------------------------------------------------
+  // getNewMessagesStream: duplicate suppression
+  // -------------------------------------------------------------------------
+  describe('getNewMessagesStream duplicate suppression', () => {
+    it('should NOT double-yield a manual tool call that was already yielded via allToolExecutionRounds', async () => {
+      // Scenario: A mixed-tools response where the model called both an auto
+      // and a manual tool. The auto tool executed, creating a round whose
+      // response.output contains BOTH the auto AND manual function_call items.
+      // The manual call also appears in finalResponse.
+      // getNewMessagesStream yields from rounds AND from yieldManualToolCalls —
+      // the manual call must appear exactly once.
+      const manualFc = makeFunctionCallItem('call_m1', 'submit', '{"data":"x"}', 'fc_m1');
+      const autoFc = makeFunctionCallItem('call_a1', 'fetch_data', '{"data":"y"}', 'fc_a1');
+
+      const roundResponse = makeResponse([autoFc, manualFc]);
+      const finalResp = makeResponse([manualFc]);
+
+      const modelResult = setupModelResult(
+        [autoTool('fetch_data'), manualTool('submit')],
+        [], // no stream events needed — we drive via rounds + finalResponse
+        {
+          finalResponse: finalResp,
+          allToolExecutionRounds: [
+            {
+              round: 1,
+              toolCalls: [
+                { id: 'call_a1', name: 'fetch_data', arguments: '{"data":"y"}' },
+              ],
+              response: roundResponse,
+              toolResults: [
+                { type: 'function_call_output', callId: 'call_a1', output: '{"ok":true}' },
+              ],
+            },
+          ],
+        },
+      );
+
+      const items: unknown[] = [];
+      for await (const item of modelResult.getNewMessagesStream()) {
+        items.push(item);
+      }
+
+      // Both function_call items from the round are yielded (auto + manual),
+      // PLUS yieldManualToolCalls may try to yield the manual one again from finalResponse.
+      // Count how many times the manual tool call appears.
+      const manualCalls = items.filter(
+        (i) => typeof i === 'object' && i !== null && 'type' in i &&
+          (i as OutputFunctionCallItem).type === 'function_call' &&
+          (i as OutputFunctionCallItem).name === 'submit',
+      );
+
+      // BUG DETECTOR: if the dedup is missing, this would be 2.
+      // The current PR code DOES NOT dedup — it yields from rounds AND from
+      // yieldManualToolCalls unconditionally. This test documents the exposure.
+      // If the count is > 1 the consumer sees the same tool call twice.
+      expect(manualCalls.length).toBeGreaterThanOrEqual(1);
+
+      // Ideally this should be exactly 1. The test below is stricter:
+      // Uncomment when dedup is added:
+      // expect(manualCalls).toHaveLength(1);
+    });
+
+    it('should yield manual tool calls from finalResponse when no rounds executed (pure manual scenario)', async () => {
+      const manualFc = makeFunctionCallItem('call_m1', 'submit', '{"data":"x"}', 'fc_m1');
+      const finalResp = makeResponse([manualFc]);
+
+      const modelResult = setupModelResult(
+        [manualTool('submit')],
+        [], // no stream events — finalResponse only
+        {
+          finalResponse: finalResp,
+          allToolExecutionRounds: [], // no auto-execute happened
+        },
+      );
+
+      const items: unknown[] = [];
+      for await (const item of modelResult.getNewMessagesStream()) {
+        items.push(item);
+      }
+
+      const manualCalls = items.filter(
+        (i) => typeof i === 'object' && i !== null && 'type' in i &&
+          (i as OutputFunctionCallItem).type === 'function_call' &&
+          (i as OutputFunctionCallItem).name === 'submit',
+      );
+
+      expect(manualCalls).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Multiple manual tools in a single response
+  // -------------------------------------------------------------------------
+  describe('multiple manual tools in single response', () => {
+    it('should yield all manual tool calls when model invokes several manual tools at once', async () => {
+      const fc1 = makeFunctionCallItem('call_1', 'tool_a', '{"data":"a"}', 'fc_1');
+      const fc2 = makeFunctionCallItem('call_2', 'tool_b', '{"data":"b"}', 'fc_2');
+      const fc3 = makeFunctionCallItem('call_3', 'tool_c', '{"data":"c"}', 'fc_3');
+
+      const finalResp = makeResponse([fc1, fc2, fc3]);
+
+      const modelResult = setupModelResult(
+        [manualTool('tool_a'), manualTool('tool_b'), manualTool('tool_c')],
+        [],
+        { finalResponse: finalResp, allToolExecutionRounds: [] },
+      );
+
+      const items: unknown[] = [];
+      for await (const item of modelResult.getNewMessagesStream()) {
+        items.push(item);
+      }
+
+      const calls = items.filter(
+        (i) => typeof i === 'object' && i !== null && 'type' in i &&
+          (i as OutputFunctionCallItem).type === 'function_call',
+      );
+
+      expect(calls).toHaveLength(3);
+      const names = calls.map((c) => (c as OutputFunctionCallItem).name);
+      expect(names).toEqual(['tool_a', 'tool_b', 'tool_c']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown tool name in response (not in tools list)
+  // -------------------------------------------------------------------------
+  describe('unknown tool name handling', () => {
+    it('should NOT yield function_call for a tool name that does not exist in the tools list', async () => {
+      // Model hallucinated a tool name that isn't registered
+      const unknownFc = makeFunctionCallItem('call_u1', 'nonexistent_tool', '{"data":"x"}', 'fc_u1');
+      const finalResp = makeResponse([unknownFc]);
+
+      const modelResult = setupModelResult(
+        [manualTool('real_tool')],
+        [],
+        { finalResponse: finalResp, allToolExecutionRounds: [] },
+      );
+
+      const items: unknown[] = [];
+      for await (const item of modelResult.getNewMessagesStream()) {
+        items.push(item);
+      }
+
+      const calls = items.filter(
+        (i) => typeof i === 'object' && i !== null && 'type' in i &&
+          (i as OutputFunctionCallItem).type === 'function_call',
+      );
+
+      // isManualToolCall requires the tool to be in the tools list, so unknown tools
+      // should NOT be yielded by yieldManualToolCalls
+      expect(calls).toHaveLength(0);
+    });
+
+    it('should NOT yield auto-execute tools via yieldManualToolCalls', async () => {
+      // An auto-execute tool in finalResponse should not be yielded as a manual call.
+      // We set allToolExecutionRounds to simulate that the auto tool already ran,
+      // and finalResponse contains the auto tool's function_call.
+      const autoFc = makeFunctionCallItem('call_a1', 'auto_fetch', '{"data":"x"}', 'fc_a1');
+      const roundResponse = makeResponse([autoFc]);
+      const finalResp = makeResponse([autoFc]);
+
+      const modelResult = setupModelResult(
+        [autoTool('auto_fetch')],
+        [],
+        {
+          finalResponse: finalResp,
+          allToolExecutionRounds: [
+            {
+              round: 1,
+              toolCalls: [{ id: 'call_a1', name: 'auto_fetch', arguments: '{"data":"x"}' }],
+              response: roundResponse,
+              toolResults: [
+                { type: 'function_call_output', callId: 'call_a1', output: '{"ok":true}' },
+              ],
+            },
+          ],
+        },
+      );
+
+      const items: unknown[] = [];
+      for await (const item of modelResult.getNewMessagesStream()) {
+        items.push(item);
+      }
+
+      // yieldManualToolCalls should NOT yield auto_fetch because it has an execute function.
+      // The only function_calls should come from the round iteration, not from yieldManualToolCalls.
+      const manualCalls = items.filter(
+        (i) => typeof i === 'object' && i !== null && 'type' in i &&
+          (i as OutputFunctionCallItem).type === 'function_call' &&
+          (i as OutputFunctionCallItem).name === 'auto_fetch',
+      );
+
+      // The round yields it once. yieldManualToolCalls should NOT add a second.
+      expect(manualCalls).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty / null finalResponse
+  // -------------------------------------------------------------------------
+  describe('null and empty finalResponse', () => {
+    it('should not crash when finalResponse is null and stream has a completion event', async () => {
+      // Provide a valid completion event so the stream doesn't throw
+      const completionEvent = responseCompletedEvent([]);
+
+      const modelResult = setupModelResult(
+        [manualTool('submit')],
+        [completionEvent],
+        { finalResponse: null, allToolExecutionRounds: [] },
+      );
+
+      const items: unknown[] = [];
+      for await (const item of modelResult.getNewMessagesStream()) {
+        items.push(item);
+      }
+
+      expect(items).toHaveLength(0);
+    });
+
+    it('should not crash when finalResponse.output is empty', async () => {
+      const finalResp = makeResponse([]);
+
+      const modelResult = setupModelResult(
+        [manualTool('submit')],
+        [],
+        { finalResponse: finalResp, allToolExecutionRounds: [] },
+      );
+
+      const items: unknown[] = [];
+      for await (const item of modelResult.getNewMessagesStream()) {
+        items.push(item);
+      }
+
+      expect(items).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Non-function_call items in finalResponse should be ignored
+  // -------------------------------------------------------------------------
+  describe('non-function_call items in finalResponse', () => {
+    it('should only yield function_call items from yieldManualToolCalls, ignoring messages and other types', async () => {
+      const manualFc = makeFunctionCallItem('call_m1', 'submit', '{"data":"x"}', 'fc_m1');
+      const messageItem = {
+        type: 'message' as const,
+        id: 'msg_1',
+        role: 'assistant' as const,
+        status: 'completed' as const,
+        content: [{ type: 'output_text' as const, text: 'Here is your result', annotations: [] }],
+      };
+
+      const finalResp = makeResponse([messageItem, manualFc]);
+
+      const modelResult = setupModelResult(
+        [manualTool('submit')],
+        [],
+        { finalResponse: finalResp, allToolExecutionRounds: [] },
+      );
+
+      const items: unknown[] = [];
+      for await (const item of modelResult.getNewMessagesStream()) {
+        items.push(item);
+      }
+
+      const calls = items.filter(
+        (i) => typeof i === 'object' && i !== null && 'type' in i &&
+          (i as OutputFunctionCallItem).type === 'function_call',
+      );
+
+      // Only the manual function_call should be yielded — message items are
+      // handled separately by the final message extraction logic, not by yieldManualToolCalls
+      expect(calls).toHaveLength(1);
+      expect((calls[0] as OutputFunctionCallItem).name).toBe('submit');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getItemsStream: mixed auto + manual — no duplication
+  // -------------------------------------------------------------------------
+  describe('getItemsStream with only manual tools — no duplication', () => {
+    it('should yield exactly one completed function_call per manual tool call', async () => {
+      const manualName = 'submit';
+      const manualArgs = '{"data":"manual"}';
+
+      const manualFc = makeFunctionCallItem('call_m1', manualName, manualArgs, 'fc_m1');
+
+      const events: OpenResponsesStreamEvent[] = [
+        ...streamEventsForToolCall('call_m1', manualName, manualArgs, 'fc_m1'),
+        responseCompletedEvent([manualFc]),
+      ];
+
+      const modelResult = setupModelResult(
+        [manualTool(manualName)],
+        events,
+      );
+
+      const items: StreamableOutputItem[] = [];
+      for await (const item of modelResult.getItemsStream()) {
+        items.push(item);
+      }
+
+      const completedFunctionCalls = items.filter(
+        (item) => isFunctionCallItem(item) && item.status === 'completed',
+      );
+
+      // The existing PR test already covers this, but here we also verify
+      // that the tool name and arguments are correct
+      expect(completedFunctionCalls).toHaveLength(1);
+      expect((completedFunctionCalls[0] as OutputFunctionCallItem).name).toBe(manualName);
+      expect((completedFunctionCalls[0] as OutputFunctionCallItem).arguments).toBe(manualArgs);
+    });
+
+    it('should yield multiple manual tools without duplication in getItemsStream', async () => {
+      const fc1 = makeFunctionCallItem('call_1', 'tool_a', '{"data":"a"}', 'fc_1');
+      const fc2 = makeFunctionCallItem('call_2', 'tool_b', '{"data":"b"}', 'fc_2');
+
+      const events: OpenResponsesStreamEvent[] = [
+        ...streamEventsForToolCall('call_1', 'tool_a', '{"data":"a"}', 'fc_1'),
+        ...streamEventsForToolCall('call_2', 'tool_b', '{"data":"b"}', 'fc_2'),
+        responseCompletedEvent([fc1, fc2]),
+      ];
+
+      const modelResult = setupModelResult(
+        [manualTool('tool_a'), manualTool('tool_b')],
+        events,
+      );
+
+      const items: StreamableOutputItem[] = [];
+      for await (const item of modelResult.getItemsStream()) {
+        items.push(item);
+      }
+
+      const completedFunctionCalls = items.filter(
+        (item) => isFunctionCallItem(item) && item.status === 'completed',
+      );
+
+      expect(completedFunctionCalls).toHaveLength(2);
+      const names = completedFunctionCalls.map(
+        (fc) => (fc as OutputFunctionCallItem).name,
+      );
+      expect(names).toContain('tool_a');
+      expect(names).toContain('tool_b');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Tool with empty arguments
+  // -------------------------------------------------------------------------
+  describe('edge case: empty arguments string', () => {
+    it('should yield manual tool call even when arguments is an empty string', async () => {
+      const fc = makeFunctionCallItem('call_1', 'no_args_tool', '', 'fc_1');
+      const finalResp = makeResponse([fc]);
+
+      const modelResult = setupModelResult(
+        [manualTool('no_args_tool')],
+        [],
+        { finalResponse: finalResp, allToolExecutionRounds: [] },
+      );
+
+      const items: unknown[] = [];
+      for await (const item of modelResult.getNewMessagesStream()) {
+        items.push(item);
+      }
+
+      const calls = items.filter(
+        (i) => typeof i === 'object' && i !== null && 'type' in i &&
+          (i as OutputFunctionCallItem).type === 'function_call',
+      );
+
+      expect(calls).toHaveLength(1);
+      expect((calls[0] as OutputFunctionCallItem).arguments).toBe('');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // in_progress status tool call in finalResponse
+  // -------------------------------------------------------------------------
+  describe('edge case: in_progress function_call in finalResponse', () => {
+    it('should still yield manual tool calls even with in_progress status', async () => {
+      // Sometimes the API may return items with unexpected statuses
+      const fc = makeFunctionCallItem('call_1', 'submit', '{"data":"x"}', 'fc_1', 'in_progress');
+      const finalResp = makeResponse([fc]);
+
+      const modelResult = setupModelResult(
+        [manualTool('submit')],
+        [],
+        { finalResponse: finalResp, allToolExecutionRounds: [] },
+      );
+
+      const items: unknown[] = [];
+      for await (const item of modelResult.getNewMessagesStream()) {
+        items.push(item);
+      }
+
+      const calls = items.filter(
+        (i) => typeof i === 'object' && i !== null && 'type' in i &&
+          (i as OutputFunctionCallItem).type === 'function_call',
+      );
+
+      // yieldManualToolCalls checks isFunctionCallItem (type === 'function_call')
+      // and isManualToolCall but does NOT filter by status,
+      // so in_progress items should still be yielded
+      expect(calls).toHaveLength(1);
+      expect((calls[0] as OutputFunctionCallItem).status).toBe('in_progress');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // No tools configured at all
+  // -------------------------------------------------------------------------
+  describe('edge case: no tools configured', () => {
+    it('should not crash when tools array is empty and finalResponse has function_calls', async () => {
+      const fc = makeFunctionCallItem('call_1', 'ghost_tool', '{"data":"x"}', 'fc_1');
+      const finalResp = makeResponse([fc]);
+
+      const modelResult = new ModelResult({
+        request: { model: 'test-model', input: 'test' },
+        client: {} as unknown as OpenRouterCore,
+        tools: [],
+      });
+
+      const internal = modelResult as unknown as InternalModelResult;
+      internal['reusableStream'] = createImmediateStream([]);
+      internal['initPromise'] = Promise.resolve();
+      internal['finalResponse'] = finalResp;
+      internal['allToolExecutionRounds'] = [];
+
+      const items: unknown[] = [];
+      for await (const item of modelResult.getNewMessagesStream()) {
+        items.push(item);
+      }
+
+      // No tools registered, so isManualToolCall returns false for everything
+      const calls = items.filter(
+        (i) => typeof i === 'object' && i !== null && 'type' in i &&
+          (i as OutputFunctionCallItem).type === 'function_call',
+      );
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Ordering: manual tool calls should appear BEFORE the final message
+  // -------------------------------------------------------------------------
+  describe('ordering: manual tool calls before final message', () => {
+    it('should yield manual tool function_calls before the final message in getNewMessagesStream', async () => {
+      const manualFc = makeFunctionCallItem('call_m1', 'submit', '{"data":"x"}', 'fc_m1');
+      const autoFc = makeFunctionCallItem('call_a1', 'fetch_data', '{"data":"y"}', 'fc_a1');
+      const messageItem = {
+        type: 'message' as const,
+        id: 'msg_1',
+        role: 'assistant' as const,
+        status: 'completed' as const,
+        content: [{ type: 'output_text' as const, text: 'Done!', annotations: [] }],
+      };
+
+      const roundResponse = makeResponse([autoFc]);
+      const finalResp = makeResponse([manualFc, messageItem]);
+
+      const modelResult = setupModelResult(
+        [autoTool('fetch_data'), manualTool('submit')],
+        [],
+        {
+          finalResponse: finalResp,
+          allToolExecutionRounds: [
+            {
+              round: 1,
+              toolCalls: [{ id: 'call_a1', name: 'fetch_data', arguments: '{"data":"y"}' }],
+              response: roundResponse,
+              toolResults: [
+                { type: 'function_call_output', callId: 'call_a1', output: '{"ok":true}' },
+              ],
+            },
+          ],
+        },
+      );
+
+      const items: unknown[] = [];
+      for await (const item of modelResult.getNewMessagesStream()) {
+        items.push(item);
+      }
+
+      // Find indices of manual function_call and message
+      const manualIdx = items.findIndex(
+        (i) => typeof i === 'object' && i !== null && 'type' in i &&
+          (i as OutputFunctionCallItem).type === 'function_call' &&
+          (i as OutputFunctionCallItem).name === 'submit',
+      );
+      const messageIdx = items.findIndex(
+        (i) => typeof i === 'object' && i !== null && 'type' in i &&
+          (i as { type: string }).type === 'message',
+      );
+
+      // Manual tool calls must come before the message
+      expect(manualIdx).toBeGreaterThanOrEqual(0);
+      expect(messageIdx).toBeGreaterThanOrEqual(0);
+      expect(manualIdx).toBeLessThan(messageIdx);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes `getNewMessagesStream()` silently dropping `function_call` items for manual tools (no `execute` function) when mixed with auto-execute tools
- The data was present in `finalResponse` but never yielded because the `finalResponse` block only yielded messages
- Now yields `function_call` items from `finalResponse` before the message, matching the existing behavior of `getItemsStream()`

Re-creation of https://github.com/OpenRouterTeam/openrouter-web/pull/16470 on this repo after the SDK was broken out of the monorepo.

## Changes

- Added `isManualToolCall()` and `yieldManualToolCalls()` helper methods to `ModelResult`
- `getNewMessagesStream()` now yields manual tool `function_call` items from `finalResponse`
- Added unit test for duplicate detection in `getItemsStream` with manual tools
- Added e2e tests for manual tool calls (mixed auto+manual, and manual-only scenarios)

## Test plan

- [x] `npm run build` passes
- [x] All unit tests pass (`npx vitest run tests/unit/`)
- [ ] E2E tests pass with live API (`npx vitest run tests/e2e/call-model.test.ts`)
- [ ] Manual verification: use `callModel` with mixed auto-execute + manual tools, consume via `getNewMessagesStream()`, confirm manual tool `function_call` items are yielded