### PR TITLE
feat: add OpenRouter wrapper class

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,10 @@
       "types": "./esm/lib/turn-context.d.ts",
       "default": "./esm/lib/turn-context.js"
     },
+    "./openrouter": {
+      "types": "./esm/openrouter.d.ts",
+      "default": "./esm/openrouter.js"
+    },
     "./package.json": "./package.json"
   },
   "sideEffects": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,8 @@ export type {
 
 // High-level model calling
 export { callModel } from './inner-loop/call-model.js';
+export { OpenRouter } from './openrouter.js';
+export type { SDKOptions } from './openrouter.js';
 export { fromClaudeMessages, toClaudeMessage } from './lib/anthropic-compat.js';
 export { hasAsyncFunctions, resolveAsyncFunctions } from './lib/async-params.js';
 export { fromChatMessages, toChatMessage } from './lib/chat-compat.js';

--- a/src/openrouter.ts
+++ b/src/openrouter.ts
@@ -1,4 +1,5 @@
 import { OpenRouterCore } from '@openrouter/sdk/core';
+import type { SDKHooks } from '@openrouter/sdk/hooks/hooks';
 import type { SDKOptions } from '@openrouter/sdk/lib/config';
 import type { RequestOptions } from '@openrouter/sdk/lib/sdks';
 import type { $ZodObject, $ZodShape, infer as zodInfer } from 'zod/v4/core';
@@ -10,13 +11,17 @@ import type { Tool } from './lib/tool-types.js';
 
 export type { SDKOptions } from '@openrouter/sdk/lib/config';
 
-export class OpenRouter {
-  private client: OpenRouterCore;
+/**
+ * SDK options extended with optional hooks for request/response interception.
+ * The underlying `ClientSDK` accepts hooks at runtime but its constructor type
+ * (`SDKOptions`) does not include them. This type bridges that gap.
+ */
+export type OpenRouterOptions = SDKOptions & { hooks?: SDKHooks };
 
-  constructor(options?: SDKOptions) {
-    this.client = new OpenRouterCore(options);
+export class OpenRouter extends OpenRouterCore {
+  constructor(options?: OpenRouterOptions) {
+    super(options);
   }
-
   callModel = <
     TTools extends readonly Tool[],
     TSharedSchema extends $ZodObject<$ZodShape> | undefined = undefined,
@@ -29,6 +34,6 @@ export class OpenRouter {
     },
     options?: RequestOptions,
   ): ModelResult<TTools, TShared> => {
-    return callModel(this.client, request, options);
+    return callModel(this, request, options);
   };
 }

--- a/src/openrouter.ts
+++ b/src/openrouter.ts
@@ -1,0 +1,34 @@
+import { OpenRouterCore } from '@openrouter/sdk/core';
+import type { SDKOptions } from '@openrouter/sdk/lib/config';
+import type { RequestOptions } from '@openrouter/sdk/lib/sdks';
+import type { $ZodObject, $ZodShape, infer as zodInfer } from 'zod/v4/core';
+
+import { callModel } from './inner-loop/call-model.js';
+import type { CallModelInput } from './lib/async-params.js';
+import type { ModelResult } from './lib/model-result.js';
+import type { Tool } from './lib/tool-types.js';
+
+export type { SDKOptions } from '@openrouter/sdk/lib/config';
+
+export class OpenRouter {
+  private client: OpenRouterCore;
+
+  constructor(options?: SDKOptions) {
+    this.client = new OpenRouterCore(options);
+  }
+
+  callModel = <
+    TTools extends readonly Tool[],
+    TSharedSchema extends $ZodObject<$ZodShape> | undefined = undefined,
+    TShared extends Record<string, unknown> = TSharedSchema extends $ZodObject<$ZodShape>
+      ? zodInfer<TSharedSchema>
+      : Record<string, never>,
+  >(
+    request: CallModelInput<TTools, TShared> & {
+      sharedContextSchema?: TSharedSchema;
+    },
+    options?: RequestOptions,
+  ): ModelResult<TTools, TShared> => {
+    return callModel(this.client, request, options);
+  };
+}

--- a/tests/unit/openrouter.test.ts
+++ b/tests/unit/openrouter.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { OpenRouterCore } from '@openrouter/sdk/core';
 import { OpenRouter } from '../../src/openrouter.js';
 import { ModelResult } from '../../src/lib/model-result.js';
 
@@ -38,5 +39,32 @@ describe('OpenRouter', () => {
       serverURL: 'https://custom.endpoint.com',
     });
     expect(openrouter).toBeInstanceOf(OpenRouter);
+  });
+
+  it('should be an instance of OpenRouterCore', () => {
+    const openrouter = new OpenRouter({ apiKey: 'test-key' });
+    expect(openrouter).toBeInstanceOf(OpenRouterCore);
+  });
+
+  it('should pass constructor options through to the instance', () => {
+    const openrouter = new OpenRouter({
+      apiKey: 'test-key',
+      serverURL: 'https://custom.endpoint.com',
+    });
+    expect(openrouter).toBeInstanceOf(OpenRouterCore);
+    // Verify the instance was constructed with the provided options
+    expect(openrouter._options.serverURL).toBe('https://custom.endpoint.com');
+  });
+
+  it('should be usable as both OpenRouter and OpenRouterCore', () => {
+    const openrouter = new OpenRouter({ apiKey: 'test-key' });
+    expect(openrouter).toBeInstanceOf(OpenRouter);
+    expect(openrouter).toBeInstanceOf(OpenRouterCore);
+    // Calling callModel should still work
+    const result = openrouter.callModel({
+      model: 'openai/gpt-4o',
+      input: 'Hello',
+    });
+    expect(result).toBeInstanceOf(ModelResult);
   });
 });

--- a/tests/unit/openrouter.test.ts
+++ b/tests/unit/openrouter.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { OpenRouter } from '../../src/openrouter.js';
+import { ModelResult } from '../../src/lib/model-result.js';
+
+describe('OpenRouter', () => {
+  it('should instantiate without options', () => {
+    const openrouter = new OpenRouter();
+    expect(openrouter).toBeInstanceOf(OpenRouter);
+  });
+
+  it('should instantiate with apiKey option', () => {
+    const openrouter = new OpenRouter({ apiKey: 'test-key' });
+    expect(openrouter).toBeInstanceOf(OpenRouter);
+  });
+
+  it('should return a ModelResult from callModel', () => {
+    const openrouter = new OpenRouter({ apiKey: 'test-key' });
+    const result = openrouter.callModel({
+      model: 'openai/gpt-4o',
+      input: 'Hello',
+    });
+    expect(result).toBeInstanceOf(ModelResult);
+  });
+
+  it('should preserve this binding when callModel is destructured', () => {
+    const openrouter = new OpenRouter({ apiKey: 'test-key' });
+    const { callModel } = openrouter;
+    const result = callModel({
+      model: 'openai/gpt-4o',
+      input: 'Hello',
+    });
+    expect(result).toBeInstanceOf(ModelResult);
+  });
+
+  it('should accept SDK options like serverURL', () => {
+    const openrouter = new OpenRouter({
+      apiKey: 'test-key',
+      serverURL: 'https://custom.endpoint.com',
+    });
+    expect(openrouter).toBeInstanceOf(OpenRouter);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an `OpenRouter` class that extends `OpenRouterCore` for a simplified single-import API
- Inherits from `OpenRouterCore` (not composition) so instances are fully compatible with the free `callModel()` function and expose all SDK namespaces (`.chat`, `.models`, etc.)
- Adds `OpenRouterOptions` type that extends `SDKOptions` with optional `hooks` support for request/response interception
- Arrow function property on `callModel` ensures correct `this` binding when destructured

```typescript
import { OpenRouter } from '@openrouter/agent';

const openrouter = new OpenRouter({ apiKey: process.env.OPENROUTER_API_KEY });
const result = openrouter.callModel({
  model: 'openai/gpt-5-nano',
  input: 'What is the capital of France?',
});
const text = await result.getText();
```

Also works with the free function since `OpenRouter` extends `OpenRouterCore`:

```typescript
import { OpenRouter, callModel } from '@openrouter/agent';

const client = new OpenRouter({ apiKey: process.env.OPENROUTER_API_KEY });
const result = callModel(client, { model: 'openai/gpt-5-nano', input: 'Hello' });
```

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test` — all 218 tests pass (8 tests for OpenRouter class)