### PR TITLE
ci: auto-trigger release on push to main

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       mode:
@@ -52,23 +55,39 @@ jobs:
 
       - run: pnpm run test
 
+      - name: Check for pending changesets
+        if: github.event_name == 'push'
+        id: changesets
+        run: |
+          if ls .changeset/*.md 1>/dev/null 2>&1; then
+            echo "pending=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pending=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create Version Packages PR
-        if: inputs.mode == 'version'
+        if: >
+          (github.event_name == 'push' && steps.changesets.outputs.pending == 'true') ||
+          (github.event_name == 'workflow_dispatch' && inputs.mode == 'version')
         uses: changesets/action@v1
         with:
           title: "chore: version packages"
           commit: "chore: version packages"
+          publish: pnpm publish --no-git-checks --provenance --access public
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm
-        if: inputs.mode == 'publish' && !inputs.dry-run
+        if: >
+          (github.event_name == 'push' && steps.changesets.outputs.pending == 'false') ||
+          (github.event_name == 'workflow_dispatch' && inputs.mode == 'publish' && !inputs.dry-run)
         run: pnpm publish --no-git-checks --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm (dry run)
-        if: inputs.mode == 'publish' && inputs.dry-run
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'publish' && inputs.dry-run
         run: pnpm publish --no-git-checks --provenance --access public --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Release workflow now triggers automatically on push to main
- If pending changesets exist → runs "version" step (creates Version Packages PR)
- If no pending changesets → runs "publish" step (publishes to npm)
- Manual `workflow_dispatch` still works as before

## Test plan
- Merge this PR, then merge the Version Packages PR (#14) — publish should auto-trigger