### PR TITLE
feat: re-export SDK model types and add item type aliases

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,67 @@
+// SDK type re-exports — every SDK type used in this package's public API
+// so consumers don't need to depend on @openrouter/sdk directly.
+
+export type { RequestOptions } from '@openrouter/sdk/lib/sdks';
+
+export type {
+  // Core request/response
+  BaseInputsUnion,
+  InputsUnion,
+  OpenResponsesResult,
+  ResponsesRequest,
+  StreamEvents,
+  Usage,
+
+  // Message & item types
+  ChatAssistantMessage,
+  ChatMessages,
+  EasyInputMessage,
+  EasyInputMessageContentUnion1,
+  EasyInputMessageRoleUnion,
+  FunctionCallItem,
+  FunctionCallOutputItem,
+  InputMessageItem,
+  OutputMessage,
+
+  // Content input types (multimodal)
+  InputAudio,
+  InputFile,
+  InputImage,
+  InputText,
+  InputVideo,
+
+  // Output item types (StreamableOutputItem members)
+  OutputFileSearchCallItem,
+  OutputFunctionCallItem,
+  OutputImageGenerationCallItem,
+  OutputReasoningItem,
+  OutputWebSearchCallItem,
+
+  // Response output content
+  ResponseOutputText,
+
+  // Error event
+  ErrorEvent,
+} from '@openrouter/sdk/models';
+
+// Clean item type aliases
+export type {
+  AssistantMessageItem,
+  CallFileSearchItem,
+  CallFunctionToolItem,
+  CallImageGenerationItem,
+  CallWebSearchItem,
+  DeveloperMessageItem,
+  ErrorItem,
+  FunctionProgressItem,
+  FunctionResultItem,
+  Item,
+  NewUserMessageItem,
+  ReasoningItem,
+  SystemMessageItem,
+  UserMessageItem,
+} from './lib/item-types.js';
+
 // Message format compatibility helpers
 
 // High-level model calling

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,42 +6,37 @@ export type { RequestOptions } from '@openrouter/sdk/lib/sdks';
 export type {
   // Core request/response
   BaseInputsUnion,
-  InputsUnion,
-  OpenResponsesResult,
-  ResponsesRequest,
-  StreamEvents,
-  Usage,
-
   // Message & item types
   ChatAssistantMessage,
   ChatMessages,
   EasyInputMessage,
   EasyInputMessageContentUnion1,
   EasyInputMessageRoleUnion,
+  // Error event
+  ErrorEvent,
   FunctionCallItem,
   FunctionCallOutputItem,
-  InputMessageItem,
-  OutputMessage,
-
   // Content input types (multimodal)
   InputAudio,
   InputFile,
   InputImage,
+  InputMessageItem,
+  InputsUnion,
   InputText,
   InputVideo,
-
+  OpenResponsesResult,
   // Output item types (StreamableOutputItem members)
   OutputFileSearchCallItem,
   OutputFunctionCallItem,
   OutputImageGenerationCallItem,
+  OutputMessage,
   OutputReasoningItem,
   OutputWebSearchCallItem,
-
   // Response output content
   ResponseOutputText,
-
-  // Error event
-  ErrorEvent,
+  ResponsesRequest,
+  StreamEvents,
+  Usage,
 } from '@openrouter/sdk/models';
 
 // Clean item type aliases

--- a/src/lib/item-types.ts
+++ b/src/lib/item-types.ts
@@ -1,9 +1,9 @@
 import type {
   EasyInputMessage,
   ErrorEvent,
-  FunctionCallItem,
   FunctionCallOutputItem,
   OutputFileSearchCallItem,
+  OutputFunctionCallItem,
   OutputImageGenerationCallItem,
   OutputMessage,
   OutputReasoningItem,
@@ -11,24 +11,29 @@ import type {
 } from '@openrouter/sdk/models';
 import type { ToolPreliminaryResultEvent } from './tool-types.js';
 
+/**
+ * Adds a required `id` field to a type, representing an item that has been
+ * persisted in conversation history (as opposed to newly created input).
+ * This is a local convention — the SDK's `EasyInputMessage` has no `id` field.
+ */
 type WithID<T> = T & { id: string };
 
 /** A function call initiated by the model */
-export type CallFunctionToolItem = FunctionCallItem;
+export type CallFunctionToolItem = OutputFunctionCallItem;
 
 /** An assistant message in the response output */
 export type AssistantMessageItem = OutputMessage;
 
-/** A new user message (input, no id) */
+/** A new user message for input (not yet persisted, no id) */
 export type NewUserMessageItem = EasyInputMessage & { role: 'user' };
 
-/** A user message with an id (from conversation history) */
+/** A user message from conversation history (has an assigned id) */
 export type UserMessageItem = WithID<EasyInputMessage> & { role: 'user' };
 
-/** A system message with an id */
+/** A system message from conversation history (has an assigned id) */
 export type SystemMessageItem = WithID<EasyInputMessage> & { role: 'system' };
 
-/** A developer message with an id */
+/** A developer message from conversation history (has an assigned id) */
 export type DeveloperMessageItem = WithID<EasyInputMessage> & { role: 'developer' };
 
 /** Reasoning output from the model */
@@ -37,11 +42,18 @@ export type ReasoningItem = OutputReasoningItem;
 /** A file search call in the response output */
 export type CallFileSearchItem = OutputFileSearchCallItem;
 
-/** The output from a function call execution */
-export type FunctionResultItem = WithID<FunctionCallOutputItem>;
+/**
+ * The output from a function call execution.
+ * `FunctionCallOutputItem` already declares `id?: string | null | undefined`,
+ * so no `WithID` wrapper is needed.
+ */
+export type FunctionResultItem = FunctionCallOutputItem;
 
-/** A preliminary result event emitted during tool execution */
-export type FunctionProgressItem = WithID<ToolPreliminaryResultEvent>;
+/**
+ * A preliminary result event emitted during tool execution.
+ * `ToolPreliminaryResultEvent` uses `toolCallId` (not `id`) for identification.
+ */
+export type FunctionProgressItem = ToolPreliminaryResultEvent;
 
 /** A web search call in the response output */
 export type CallWebSearchItem = OutputWebSearchCallItem;
@@ -49,10 +61,19 @@ export type CallWebSearchItem = OutputWebSearchCallItem;
 /** An image generation call in the response output */
 export type CallImageGenerationItem = OutputImageGenerationCallItem;
 
-/** A streaming error event */
-export type ErrorItem = WithID<ErrorEvent>;
+/**
+ * A streaming error event.
+ * `ErrorEvent` has no `id` field; it uses `code`, `message`, `param`, and `sequenceNumber`.
+ */
+export type ErrorItem = ErrorEvent;
 
-/** Union of all item types */
+/**
+ * Union of all item types used by this package.
+ *
+ * This is not exhaustive over every possible SDK output item type —
+ * server tool items (e.g. `OutputDatetimeItem`, `OutputServerToolItem`)
+ * are not included. Extend this union if you need to handle those.
+ */
 export type Item =
   | AssistantMessageItem
   | UserMessageItem

--- a/src/lib/item-types.ts
+++ b/src/lib/item-types.ts
@@ -1,0 +1,69 @@
+import type {
+  EasyInputMessage,
+  ErrorEvent,
+  FunctionCallItem,
+  FunctionCallOutputItem,
+  OutputFileSearchCallItem,
+  OutputImageGenerationCallItem,
+  OutputMessage,
+  OutputReasoningItem,
+  OutputWebSearchCallItem,
+} from '@openrouter/sdk/models';
+import type { ToolPreliminaryResultEvent } from './tool-types.js';
+
+type WithID<T> = T & { id: string };
+
+/** A function call initiated by the model */
+export type CallFunctionToolItem = FunctionCallItem;
+
+/** An assistant message in the response output */
+export type AssistantMessageItem = OutputMessage;
+
+/** A new user message (input, no id) */
+export type NewUserMessageItem = EasyInputMessage & { role: 'user' };
+
+/** A user message with an id (from conversation history) */
+export type UserMessageItem = WithID<EasyInputMessage> & { role: 'user' };
+
+/** A system message with an id */
+export type SystemMessageItem = WithID<EasyInputMessage> & { role: 'system' };
+
+/** A developer message with an id */
+export type DeveloperMessageItem = WithID<EasyInputMessage> & { role: 'developer' };
+
+/** Reasoning output from the model */
+export type ReasoningItem = OutputReasoningItem;
+
+/** A file search call in the response output */
+export type CallFileSearchItem = OutputFileSearchCallItem;
+
+/** The output from a function call execution */
+export type FunctionResultItem = WithID<FunctionCallOutputItem>;
+
+/** A preliminary result event emitted during tool execution */
+export type FunctionProgressItem = WithID<ToolPreliminaryResultEvent>;
+
+/** A web search call in the response output */
+export type CallWebSearchItem = OutputWebSearchCallItem;
+
+/** An image generation call in the response output */
+export type CallImageGenerationItem = OutputImageGenerationCallItem;
+
+/** A streaming error event */
+export type ErrorItem = WithID<ErrorEvent>;
+
+/** Union of all item types */
+export type Item =
+  | AssistantMessageItem
+  | UserMessageItem
+  | SystemMessageItem
+  | DeveloperMessageItem
+  | NewUserMessageItem
+  | CallFunctionToolItem
+  | ReasoningItem
+  | CallFileSearchItem
+  | FunctionResultItem
+  | FunctionProgressItem
+  | CallWebSearchItem
+  | CallImageGenerationItem
+  | ErrorItem;

--- a/src/lib/item-types.ts
+++ b/src/lib/item-types.ts
@@ -16,7 +16,9 @@ import type { ToolPreliminaryResultEvent } from './tool-types.js';
  * persisted in conversation history (as opposed to newly created input).
  * This is a local convention — the SDK's `EasyInputMessage` has no `id` field.
  */
-type WithID<T> = T & { id: string };
+type WithID<T> = T & {
+  id: string;
+};
 
 /** A function call initiated by the model */
 export type CallFunctionToolItem = OutputFunctionCallItem;
@@ -25,16 +27,24 @@ export type CallFunctionToolItem = OutputFunctionCallItem;
 export type AssistantMessageItem = OutputMessage;
 
 /** A new user message for input (not yet persisted, no id) */
-export type NewUserMessageItem = EasyInputMessage & { role: 'user' };
+export type NewUserMessageItem = EasyInputMessage & {
+  role: 'user';
+};
 
 /** A user message from conversation history (has an assigned id) */
-export type UserMessageItem = WithID<EasyInputMessage> & { role: 'user' };
+export type UserMessageItem = WithID<EasyInputMessage> & {
+  role: 'user';
+};
 
 /** A system message from conversation history (has an assigned id) */
-export type SystemMessageItem = WithID<EasyInputMessage> & { role: 'system' };
+export type SystemMessageItem = WithID<EasyInputMessage> & {
+  role: 'system';
+};
 
 /** A developer message from conversation history (has an assigned id) */
-export type DeveloperMessageItem = WithID<EasyInputMessage> & { role: 'developer' };
+export type DeveloperMessageItem = WithID<EasyInputMessage> & {
+  role: 'developer';
+};
 
 /** Reasoning output from the model */
 export type ReasoningItem = OutputReasoningItem;


### PR DESCRIPTION
## Summary

- Re-exports all 28 SDK types used in this package's public API (`InputsUnion`, `OpenResponsesResult`, `EasyInputMessage`, `InputAudio`, `InputFile`, etc.) so consumers don't need to install `@openrouter/sdk` separately just to annotate their variables
- Adds clean item type aliases (`Item`, `AssistantMessageItem`, `CallFunctionToolItem`, `ErrorItem`, etc.) in `src/lib/item-types.ts` that provide user-friendly names over the raw SDK types

## Test plan

- [x] `pnpm run build` passes (type-only exports, zero runtime impact)
- [x] All 218 unit tests pass
- [x] Verified re-exported types appear in built `esm/index.d.ts`