### PR TITLE
Release v0.2.0

### DIFF
--- a/.changeset/export-sdk-types.md
+++ b/.changeset/export-sdk-types.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/agent": minor
+---
+
+Re-export SDK model types and add clean item type aliases so consumers don't need to depend on `@openrouter/sdk` directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @openrouter/agent
 
+## 0.2.0
+
+### Minor Changes
+
+- Re-export SDK model types (`ResponsesRequest`, `OutputMessage`, `FunctionCallItem`, etc.) from `@openrouter/sdk/models` so consumers don't need a direct dependency on `@openrouter/sdk`.
+- Add clean item type aliases (`Item`, `UserMessageItem`, `AssistantMessageItem`, `FunctionResultItem`, etc.) via new `@openrouter/agent` exports.
+- Add `OpenRouter` wrapper class that extends `OpenRouterCore` for a simplified API (`@openrouter/agent/openrouter`).
+
+### Patch Changes
+
+- Replace ESLint with Biome for linting and formatting.
+- Add CI auto-release workflow on push to main.
+- Correct item type aliases to match SDK runtime types.
+
 ## 0.1.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/agent",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": "OpenRouter",
   "description": "Agent toolkit for building AI applications with OpenRouter — tool orchestration, streaming, multi-turn conversations, and format compatibility.",
   "keywords": [


### PR DESCRIPTION
## Summary

- Re-export SDK model types (`ResponsesRequest`, `OutputMessage`, `FunctionCallItem`, etc.) so consumers don't need a direct dependency on `@openrouter/sdk`
- Add clean item type aliases (`Item`, `UserMessageItem`, `AssistantMessageItem`, `FunctionResultItem`, etc.)
- Add `OpenRouter` wrapper class extending `OpenRouterCore` for a simplified API
- Replace ESLint with Biome for linting and formatting
- Add CI auto-release workflow on push to main

## Version

`0.1.2` → `0.2.0` (minor — new public API surface)

## Test plan

- [ ] `pnpm test` passes
- [ ] `pnpm build` succeeds
- [ ] `pnpm lint` passes
- [ ] Verify new exports are accessible from consuming packages