### PR TITLE
chore: add changeset for type fixes (patch)

### DIFF
--- a/.changeset/fix-types-exports.md
+++ b/.changeset/fix-types-exports.md
@@ -1,0 +1,9 @@
+---
+"@openrouter/agent": patch
+---
+
+Fix type exports and package publishing configuration
+
+- Add `NewDeveloperMessageItem` type export for manually added developer messages
+- Fix `FieldOrAsyncFunction` type import path in async-params module
+- Add `.npmignore` to exclude development files from published package

--- a/.changeset/fix-types-exports.md
+++ b/.changeset/fix-types-exports.md
@@ -2,8 +2,9 @@
 "@openrouter/agent": patch
 ---
 
-Fix type exports and package publishing configuration
+Fix type exports and add pre-push hooks
 
 - Add `NewDeveloperMessageItem` type export for manually added developer messages
 - Fix `FieldOrAsyncFunction` type import path in async-params module
 - Add `.npmignore` to exclude development files from published package
+- Add husky pre-push hooks for lint and typecheck validation

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm run lint && pnpm run typecheck

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "test:watch": "vitest --watch --project unit",
     "typecheck": "tsc --noEmit",
     "compile": "tsc",
-    "prepare": "npm run build"
+    "prepare": "husky"
   },
   "dependencies": {
     "@openrouter/sdk": "*",
@@ -123,6 +123,7 @@
     "@changesets/cli": "^2.30.0",
     "@types/node": "^22.13.12",
     "dotenv": "^16.4.7",
+    "husky": "^9.1.7",
     "typescript": "~5.8.3",
     "vitest": "^3.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -673,6 +676,11 @@ packages:
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
+    hasBin: true
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   iconv-lite@0.7.2:
@@ -1658,6 +1666,8 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   human-id@4.1.3: {}
+
+  husky@9.1.7: {}
 
   iconv-lite@0.7.2:
     dependencies:

--- a/src/lib/async-params.ts
+++ b/src/lib/async-params.ts
@@ -1,5 +1,6 @@
 import type * as models from '@openrouter/sdk/models';
 import type { OpenResponsesResult } from '@openrouter/sdk/models';
+import type { Item } from './item-types.js';
 import type { ContextInput } from './tool-context.js';
 import type {
   ParsedToolCall,
@@ -9,7 +10,6 @@ import type {
   ToolContextMapWithShared,
   TurnContext,
 } from './tool-types.js';
-import { Item } from './item-types.js';
 
 // Re-export Tool type for convenience
 export type { Tool } from './tool-types.js';

--- a/src/lib/item-types.ts
+++ b/src/lib/item-types.ts
@@ -51,7 +51,6 @@ export type NewDeveloperMessageItem = EasyInputMessage & {
   role: 'developer';
 };
 
-
 /** Reasoning output from the model */
 export type ReasoningItem = OutputReasoningItem;
 


### PR DESCRIPTION
## Summary
- Adds changeset for the `fix types` commit (ef45886)
- Prepares patch release (0.3.0 → 0.3.1)

## Changes included in this release
- Add `NewDeveloperMessageItem` type export for manually added developer messages
- Fix `FieldOrAsyncFunction` type import path in async-params module  
- Add `.npmignore` to exclude development files from published package

## Test plan
- [ ] Verify changeset format is correct
- [ ] Merge to trigger changeset release workflow