### PR TITLE
fix(openrouter): normalize hooks constructor option so shorthand input isn't silently dropped

### DIFF
--- a/.changeset/fix-hook-shorthand.md
+++ b/.changeset/fix-hook-shorthand.md
@@ -1,0 +1,13 @@
+---
+'@openrouter/agent': patch
+---
+
+Fix `hooks` constructor option silently no-oping when a plain hook object (e.g. `{ beforeRequest: ... }`) was passed: the underlying SDK only honors `hooks` when it is an `SDKHooks` instance, and the previous wrapper forwarded the plain object unchanged.
+
+`new OpenRouter({ hooks })` now accepts any of:
+
+- an `SDKHooks` instance (used as-is),
+- a single hook object (`BeforeRequestHook`, `AfterSuccessHook`, etc.), or
+- an array of hook objects.
+
+Shorthand inputs are normalized into an `SDKHooks` instance before handoff. Hook types (`BeforeRequestHook`, `BeforeRequestContext`, `AfterSuccessHook`, `SDKHooks`, etc.) are now re-exported from the package entry point.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,20 @@
 // SDK type re-exports — every SDK type used in this package's public API
 // so consumers don't need to depend on @openrouter/sdk directly.
 
+// Hooks — interception points for requests and responses
+export { SDKHooks } from '@openrouter/sdk/hooks/hooks';
+export type {
+  AfterErrorContext,
+  AfterErrorHook,
+  AfterSuccessContext,
+  AfterSuccessHook,
+  BeforeCreateRequestContext,
+  BeforeCreateRequestHook,
+  BeforeRequestContext,
+  BeforeRequestHook,
+  HookContext,
+  SDKInitHook,
+} from '@openrouter/sdk/hooks/types';
 export type { RequestOptions } from '@openrouter/sdk/lib/sdks';
 
 export type {
@@ -174,5 +188,5 @@ export {
 } from './lib/tool-types.js';
 // Turn context helpers
 export { buildTurnContext, normalizeInputToArray } from './lib/turn-context.js';
-export type { SDKOptions } from './openrouter.js';
+export type { Hook, OpenRouterOptions, SDKOptions } from './openrouter.js';
 export { OpenRouter } from './openrouter.js';

--- a/src/openrouter.ts
+++ b/src/openrouter.ts
@@ -1,5 +1,12 @@
 import { OpenRouterCore } from '@openrouter/sdk/core';
-import type { SDKHooks } from '@openrouter/sdk/hooks/hooks';
+import { SDKHooks } from '@openrouter/sdk/hooks/hooks';
+import type {
+  AfterErrorHook,
+  AfterSuccessHook,
+  BeforeCreateRequestHook,
+  BeforeRequestHook,
+  SDKInitHook,
+} from '@openrouter/sdk/hooks/types';
 import type { SDKOptions } from '@openrouter/sdk/lib/config';
 import type { RequestOptions } from '@openrouter/sdk/lib/sdks';
 import type { $ZodObject, $ZodShape, infer as zodInfer } from 'zod/v4/core';
@@ -11,16 +18,71 @@ import type { Tool } from './lib/tool-types.js';
 
 export type { SDKOptions } from '@openrouter/sdk/lib/config';
 
+/** Any single hook interface supported by the underlying SDK. */
+export type Hook =
+  | SDKInitHook
+  | BeforeCreateRequestHook
+  | BeforeRequestHook
+  | AfterSuccessHook
+  | AfterErrorHook;
+
 /**
  * SDK options extended with optional hooks for request/response interception.
- * The underlying `ClientSDK` accepts hooks at runtime but its constructor type
- * (`SDKOptions`) does not include them. This type bridges that gap.
+ * `hooks` accepts an `SDKHooks` instance, a single hook object, or an array of
+ * hook objects; the constructor normalizes shorthand input into an `SDKHooks`
+ * instance before passing it to the underlying SDK, which only recognizes
+ * `hooks` when it is an `SDKHooks` instance.
  */
 export type OpenRouterOptions = SDKOptions & {
-  hooks?: SDKHooks;
+  hooks?: SDKHooks | Hook | readonly Hook[];
 };
 
+function buildSDKHooks(input: SDKHooks | Hook | readonly Hook[] | undefined): SDKHooks | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+  if (input instanceof SDKHooks) {
+    return input;
+  }
+  const hooks = new SDKHooks();
+  const list: readonly Hook[] = Array.isArray(input)
+    ? input
+    : [
+        input,
+      ];
+  for (const hook of list) {
+    if ('sdkInit' in hook) {
+      hooks.registerSDKInitHook(hook);
+    }
+    if ('beforeCreateRequest' in hook) {
+      hooks.registerBeforeCreateRequestHook(hook);
+    }
+    if ('beforeRequest' in hook) {
+      hooks.registerBeforeRequestHook(hook);
+    }
+    if ('afterSuccess' in hook) {
+      hooks.registerAfterSuccessHook(hook);
+    }
+    if ('afterError' in hook) {
+      hooks.registerAfterErrorHook(hook);
+    }
+  }
+  return hooks;
+}
+
 export class OpenRouter extends OpenRouterCore {
+  constructor(options?: OpenRouterOptions) {
+    const { hooks: hooksInput, ...rest } = options ?? {};
+    const hooks = buildSDKHooks(hooksInput);
+    super(
+      hooks === undefined
+        ? rest
+        : Object.assign({}, rest, {
+            hooks,
+          }),
+    );
+  }
+
   callModel = <
     TTools extends readonly Tool[],
     TSharedSchema extends $ZodObject<$ZodShape> | undefined = undefined,

--- a/tests/e2e/call-model.test.ts
+++ b/tests/e2e/call-model.test.ts
@@ -1,4 +1,3 @@
-import { OpenRouter, ToolType } from '@openrouter/sdk';
 import type { ClaudeMessageParam } from '@openrouter/sdk/models/claude-message';
 import type { OpenResponsesFunctionCallOutput } from '@openrouter/sdk/models/openresponsesfunctioncalloutput';
 import type { OpenResponsesNonStreamingResponse } from '@openrouter/sdk/models/openresponsesnonstreamingresponse';
@@ -7,6 +6,7 @@ import type { OutputFunctionCallItem } from '@openrouter/sdk/models/outputfuncti
 import type { ResponsesOutputMessage } from '@openrouter/sdk/models/responsesoutputmessage';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
+import { OpenRouter, ToolType } from '../../src/index.js';
 import { fromClaudeMessages } from '../../src/lib/anthropic-compat.js';
 import { fromChatMessages, toChatMessage } from '../../src/lib/chat-compat.js';
 import { stepCountIs } from '../../src/lib/stop-conditions.js';
@@ -726,7 +726,7 @@ describe('callModel E2E Tests', () => {
           expect(lastMessageIndex).toBeGreaterThan(lastFnOutputIndex);
         }
       }
-    }, 6000);
+    }, 20000);
 
     it('should return messages with all required fields and correct types', async () => {
       const response = client.callModel({

--- a/tests/unit/openrouter.test.ts
+++ b/tests/unit/openrouter.test.ts
@@ -1,4 +1,10 @@
 import { OpenRouterCore } from '@openrouter/sdk/core';
+import { SDKHooks } from '@openrouter/sdk/hooks/hooks';
+import type {
+  AfterSuccessHook,
+  BeforeRequestContext,
+  BeforeRequestHook,
+} from '@openrouter/sdk/hooks/types';
 import { describe, expect, it } from 'vitest';
 import { ModelResult } from '../../src/lib/model-result.js';
 import { OpenRouter } from '../../src/openrouter.js';
@@ -76,5 +82,68 @@ describe('OpenRouter', () => {
       input: 'Hello',
     });
     expect(result).toBeInstanceOf(ModelResult);
+  });
+
+  describe('hooks', () => {
+    const noopBeforeRequest: BeforeRequestHook = {
+      beforeRequest: async (_ctx: BeforeRequestContext, request: Request) => request,
+    };
+    const noopAfterSuccess: AfterSuccessHook = {
+      afterSuccess: async (_ctx, response) => response,
+    };
+
+    it('should expose an SDKHooks instance on _options by default', () => {
+      const openrouter = new OpenRouter({
+        apiKey: 'test-key',
+      });
+      expect(openrouter._options.hooks).toBeInstanceOf(SDKHooks);
+    });
+
+    it('should use a passed SDKHooks instance as-is', () => {
+      const hooks = new SDKHooks();
+      hooks.registerBeforeRequestHook(noopBeforeRequest);
+      const openrouter = new OpenRouter({
+        apiKey: 'test-key',
+        hooks,
+      });
+      expect(openrouter._options.hooks).toBe(hooks);
+      expect(openrouter._options.hooks?.beforeRequestHooks).toHaveLength(1);
+    });
+
+    it('should wrap a single hook object into an SDKHooks instance', () => {
+      const openrouter = new OpenRouter({
+        apiKey: 'test-key',
+        hooks: noopBeforeRequest,
+      });
+      expect(openrouter._options.hooks).toBeInstanceOf(SDKHooks);
+      expect(openrouter._options.hooks?.beforeRequestHooks).toHaveLength(1);
+      expect(openrouter._options.hooks?.beforeRequestHooks[0]).toBe(noopBeforeRequest);
+    });
+
+    it('should wrap an array of hook objects into an SDKHooks instance', () => {
+      const openrouter = new OpenRouter({
+        apiKey: 'test-key',
+        hooks: [
+          noopBeforeRequest,
+          noopAfterSuccess,
+        ],
+      });
+      expect(openrouter._options.hooks).toBeInstanceOf(SDKHooks);
+      expect(openrouter._options.hooks?.beforeRequestHooks).toHaveLength(1);
+      expect(openrouter._options.hooks?.afterSuccessHooks).toHaveLength(1);
+    });
+
+    it('should register a hook object that implements multiple hook interfaces under every matching slot', () => {
+      const combined: BeforeRequestHook & AfterSuccessHook = {
+        beforeRequest: async (_ctx, request) => request,
+        afterSuccess: async (_ctx, response) => response,
+      };
+      const openrouter = new OpenRouter({
+        apiKey: 'test-key',
+        hooks: combined,
+      });
+      expect(openrouter._options.hooks?.beforeRequestHooks).toHaveLength(1);
+      expect(openrouter._options.hooks?.afterSuccessHooks).toHaveLength(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes 11 failing e2e tests on `main` that stem from two root causes in the `OpenRouter` wrapper and a couple of test-file issues.

### 1. `hooks: <plainHookObject>` silently did nothing

The underlying `ClientSDK` only wires the `hooks` constructor option into the request pipeline when it's an `instanceof SDKHooks`. Our wrapper forwarded the option unchanged, so every caller who used the natural shorthand (`new OpenRouter({ hooks: { beforeRequest } })`) got a live-looking `hooks` field that was silently replaced by an empty registry.

This caused 8 `multi-turn-tool-state.test.ts` failures where a `BeforeRequestHook` was supposed to capture outbound requests but `capturedRequests.length` was always 0.

**Fix:** `src/openrouter.ts` now normalizes the `hooks` option into an `SDKHooks` instance before calling `super`. Accepts:

- an existing `SDKHooks` instance (used as-is),
- a single hook object (`BeforeRequestHook`, `AfterSuccessHook`, etc.), or
- an array of hook objects.

`SDKHooks`, `Hook`, `BeforeRequestHook`, `BeforeRequestContext`, `AfterSuccessHook`, and the rest of the hook interfaces/context types are re-exported from the package entry point so consumers don't need to reach into `@openrouter/sdk/hooks/*`.

### 2. `call-model.test.ts` used the upstream SDK's `OpenRouter`

The test imported `OpenRouter` and `ToolType` from `@openrouter/sdk`, exercising the SDK's older `ModelResult.getNewMessagesStream` — which doesn't yield manual-tool `function_call` items from `finalResponse`. Local `src/lib/model-result.ts` does (lines 1745-1757), and the tests assert on that behavior.

**Fix:** import `OpenRouter` and `ToolType` from `../../src/index.js`.

### 3. One test had a 6s timeout for a Sonnet 4.5 + tool round-trip

Bumped to 20s.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 237/237 pass (includes 5 new unit tests covering `SDKHooks` passthrough, single-hook wrapping, array wrapping, and multi-interface hooks)
- [x] `pnpm run test:e2e` (with `OPENROUTER_API_KEY`) — 94/94 pass (was 83/94 before)

## Changeset

Patch-level; public API is strictly additive (new hook shorthand input types on the existing `hooks` option, plus re-exports).