### PR TITLE
feat: add OpenRouter server tools to callModel

### DIFF
--- a/.changeset/add-server-tools.md
+++ b/.changeset/add-server-tools.md
@@ -1,0 +1,9 @@
+---
+"@openrouter/agent": minor
+---
+
+Add `serverTool()` factory for OpenRouter's server-executed tools (web search, `openrouter:datetime`, image generation, MCP, file search, code interpreter, and future SDK additions). Server tools can be mixed with client `tool()`s in the `callModel({ tools })` array; OpenRouter runs them and their output items flow through the unified `ModelResult.allToolExecutionRounds[].toolResults` list.
+
+- `getItemsStream()` yields server-tool output items (e.g. `web_search_call`, `openrouter:datetime`) alongside client `function_call` / `function_call_output` items. The yielded union is narrowed from the `TTools` passed to `callModel`, so consumers only see item types that are reachable for their tool set.
+- `StepResult.serverToolResults` exposes provider-side tool invocations to `stopWhen` conditions (the existing `toolResults` field remains client-tool-only).
+- New public exports: `serverTool`, `isServerTool`, `isClientTool`, and the types `ServerTool`, `ServerToolConfig`, `ServerToolType`, `ServerToolResultItem`, `ClientTool`, `ToolResultItem`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,12 +46,15 @@ export type {
   OutputFunctionCallItem,
   OutputImageGenerationCallItem,
   OutputInputImage,
+  OutputItems,
   OutputMessage,
   OutputReasoningItem,
+  OutputServerToolItem,
   OutputWebSearchCallItem,
   // Response output content
   ResponseOutputText,
   ResponsesRequest,
+  ResponsesRequestToolUnion,
   StreamEvents,
   Usage,
 } from '@openrouter/sdk/models';
@@ -124,7 +127,7 @@ export {
   hasUnsupportedContent,
 } from './lib/stream-transformers.js';
 // Tool creation helpers
-export { tool } from './lib/tool.js';
+export { serverTool, tool } from './lib/tool.js';
 export type { ContextInput } from './lib/tool-context.js';
 // Tool context helpers
 export { buildToolExecuteContext, ToolContextStore } from './lib/tool-context.js';
@@ -132,6 +135,7 @@ export { buildToolExecuteContext, ToolContextStore } from './lib/tool-context.js
 export { ToolEventBroadcaster } from './lib/tool-event-broadcaster.js';
 export type {
   ChatStreamEvent,
+  ClientTool,
   ConversationState,
   ConversationStatus,
   HasApprovalTools,
@@ -147,6 +151,10 @@ export type {
   PartialResponse,
   ResponseStreamEvent,
   ResponseStreamEvent as EnhancedResponseStreamEvent,
+  ServerTool,
+  ServerToolConfig,
+  ServerToolResultItem,
+  ServerToolType,
   StateAccessor,
   StepResult,
   StopCondition,
@@ -162,6 +170,7 @@ export type {
   ToolOutputContentItem,
   ToolPreliminaryResultEvent,
   ToolResultEvent,
+  ToolResultItem,
   ToolStreamEvent,
   ToolWithExecute,
   ToolWithGenerator,
@@ -176,8 +185,10 @@ export type {
 export {
   hasApprovalRequiredTools,
   hasExecuteFunction,
+  isClientTool,
   isGeneratorTool,
   isRegularExecuteTool,
+  isServerTool,
   isToolCallOutputEvent,
   isToolPreliminaryResultEvent,
   isToolResultEvent,

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,6 @@ export type {
   OutputItems,
   OutputMessage,
   OutputReasoningItem,
-  OutputServerToolItem,
   OutputWebSearchCallItem,
   // Response output content
   ResponseOutputText,

--- a/src/lib/conversation-state.ts
+++ b/src/lib/conversation-state.ts
@@ -6,6 +6,7 @@ import type {
   TurnContext,
   UnsentToolResult,
 } from './tool-types.js';
+import { isClientTool } from './tool-types.js';
 
 import { normalizeInputToArray } from './turn-context.js';
 
@@ -124,21 +125,44 @@ export async function toolRequiresApproval<TTools extends readonly Tool[]>(
     return callLevelCheck(toolCall, context);
   }
 
-  // Fall back to tool-level setting
-  const tool = tools.find((t) => t.function.name === toolCall.name);
+  // Fall back to tool-level setting (server tools never require approval)
+  const tool = tools.find(
+    (
+      t,
+    ): t is Exclude<
+      Tool,
+      {
+        _brand: 'server-tool';
+      }
+    > => isClientTool(t) && t.function.name === toolCall.name,
+  );
   if (!tool) {
     return false;
   }
 
   const requireApproval = tool.function.requireApproval;
 
-  // If it's a function, call it with the tool's arguments and context
+  // If it's a function, call it with the tool's arguments and context.
+  // Arguments have already been parsed and validated against the tool's
+  // Zod inputSchema (a ZodObject), so the runtime shape is always a
+  // record here. A non-record value signals a real upstream bug — surface
+  // it rather than substituting an empty object.
   if (typeof requireApproval === 'function') {
-    return requireApproval(toolCall.arguments, context);
+    const rawArgs: unknown = toolCall.arguments;
+    if (!isRecord(rawArgs)) {
+      throw new Error(
+        `toolCall.arguments for "${toolCall.name}" must be an object after Zod validation, got ${rawArgs === null ? 'null' : Array.isArray(rawArgs) ? 'array' : typeof rawArgs}`,
+      );
+    }
+    return requireApproval(rawArgs, context);
   }
 
   // Otherwise treat as boolean
   return requireApproval ?? false;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /**

--- a/src/lib/model-result.ts
+++ b/src/lib/model-result.ts
@@ -58,6 +58,7 @@ import type {
   InferToolOutputsUnion,
   ParsedToolCall,
   ResponseStreamEvent,
+  ServerToolResultItem,
   StateAccessor,
   StopWhen,
   Tool,
@@ -570,6 +571,8 @@ export class ModelResult<
 
     const isFunctionCallOutput = (tr: ToolResultItem): tr is models.FunctionCallOutputItem =>
       tr.type === 'function_call_output';
+    const isServerToolResult = (tr: ToolResultItem): tr is ServerToolResultItem =>
+      tr.type !== 'function_call_output';
 
     return isStopConditionMet({
       stopConditions,
@@ -577,12 +580,15 @@ export class ModelResult<
         stepType: 'continue' as const,
         text: extractTextFromResponse(round.response),
         toolCalls: round.toolCalls,
-        // stopWhen step model is client-tool-centric; skip server tool items.
+        // `toolResults` is client-tool-centric; server-tool output items are
+        // surfaced on `serverToolResults` so stop conditions can react to
+        // either class of result.
         toolResults: round.toolResults.filter(isFunctionCallOutput).map((tr) => ({
           toolCallId: tr.callId,
           toolName: round.toolCalls.find((tc) => tc.id === tr.callId)?.name ?? '',
           result: typeof tr.output === 'string' ? JSON.parse(tr.output) : tr.output,
         })),
+        serverToolResults: round.toolResults.filter(isServerToolResult),
         response: round.response,
         usage: round.response.usage,
         finishReason: undefined,
@@ -1853,8 +1859,17 @@ export class ModelResult<
         case 'web_search_2025_08_26':
         case 'web_search_preview':
         case 'web_search_preview_2025_03_11':
-        case 'openrouter:web_search':
           allowed.add('web_search_call');
+          break;
+        case 'openrouter:web_search':
+          // Defensive: OpenRouter's web_search variant may emit either the
+          // standard OutputWebSearchCallItem (type='web_search_call') OR be
+          // wrapped in OutputServerToolItem with type='openrouter:web_search'.
+          // Accept both literals so the runtime filter doesn't silently drop
+          // valid items. Do NOT set acceptGenericServerItem — we know the
+          // tool type and want the filter narrow.
+          allowed.add('web_search_call');
+          allowed.add('openrouter:web_search');
           break;
         case 'file_search':
           allowed.add('file_search_call');

--- a/src/lib/model-result.ts
+++ b/src/lib/model-result.ts
@@ -1877,6 +1877,13 @@ export class ModelResult<
         case 'image_generation':
           allowed.add('image_generation_call');
           break;
+        case 'openrouter:datetime':
+          // Known server tool whose SDK output item uses the same literal
+          // as the request type. Mirrors `KnownServerToolOutputs` in
+          // stream-transformers.ts so the runtime filter stays as narrow
+          // as the compile-time union (no acceptGenericServerItem widening).
+          allowed.add('openrouter:datetime');
+          break;
         default:
           // Unknown / generic server tool — at runtime its output items
           // pass through as the request-type literal or as the SDK's

--- a/src/lib/model-result.ts
+++ b/src/lib/model-result.ts
@@ -40,11 +40,13 @@ import {
 import {
   hasTypeProperty,
   isFunctionCallItem,
+  isFunctionCallOutputItem,
   isOutputTextDeltaEvent,
   isReasoningDeltaEvent,
   isResponseCompletedEvent,
   isResponseFailedEvent,
   isResponseIncompleteEvent,
+  isServerToolResultItem,
 } from './stream-type-guards.js';
 import type { ContextInput } from './tool-context.js';
 import { resolveContext, ToolContextStore } from './tool-context.js';
@@ -61,19 +63,32 @@ import type {
   Tool,
   ToolCallOutputEvent,
   ToolContextMapWithShared,
+  ToolResultItem,
   ToolStreamEvent,
   TurnContext,
   TurnEndEvent,
   TurnStartEvent,
   UnsentToolResult,
 } from './tool-types.js';
-import { hasExecuteFunction, isToolCallOutputEvent } from './tool-types.js';
+import {
+  hasExecuteFunction,
+  isClientTool,
+  isServerTool,
+  isToolCallOutputEvent,
+} from './tool-types.js';
 
 /**
  * Default maximum number of tool execution steps if no stopWhen is specified.
  * This prevents infinite loops in tool execution.
  */
 const DEFAULT_MAX_STEPS = 5;
+
+/**
+ * Typeguard for plain-object records (non-null, non-array).
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
 
 /**
  * Type guard for stream event with toReadableStream method
@@ -178,7 +193,14 @@ export class ModelResult<
     round: number;
     toolCalls: ParsedToolCall<Tool>[];
     response: models.OpenResponsesResult;
-    toolResults: Array<models.FunctionCallOutputItem>;
+    /**
+     * All tool outputs from this round — both client function outputs we send
+     * back AND server-tool output items emitted by OpenRouter (web_search_call,
+     * image_generation_call, file_search_call, openrouter:datetime, generic
+     * OutputServerToolItem, etc.). Type derived from the SDK's OutputItems
+     * union so new server-tool variants appear automatically.
+     */
+    toolResults: Array<ToolResultItem>;
   }> = [];
   // Track resolved request after async function resolution
   private resolvedRequest: models.ResponsesRequest | null = null;
@@ -546,13 +568,17 @@ export class ModelResult<
           stopWhen,
         ];
 
+    const isFunctionCallOutput = (tr: ToolResultItem): tr is models.FunctionCallOutputItem =>
+      tr.type === 'function_call_output';
+
     return isStopConditionMet({
       stopConditions,
       steps: this.allToolExecutionRounds.map((round) => ({
         stepType: 'continue' as const,
         text: extractTextFromResponse(round.response),
         toolCalls: round.toolCalls,
-        toolResults: round.toolResults.map((tr) => ({
+        // stopWhen step model is client-tool-centric; skip server tool items.
+        toolResults: round.toolResults.filter(isFunctionCallOutput).map((tr) => ({
           toolCallId: tr.callId,
           toolName: round.toolCalls.find((tc) => tc.id === tr.callId)?.name ?? '',
           result: typeof tr.output === 'string' ? JSON.parse(tr.output) : tr.output,
@@ -573,13 +599,15 @@ export class ModelResult<
    */
   private hasExecutableToolCalls(toolCalls: ParsedToolCall<Tool>[]): boolean {
     return toolCalls.some((toolCall) => {
-      const tool = this.options.tools?.find((t) => t.function.name === toolCall.name);
+      const tool = this.options.tools?.find(
+        (t) => isClientTool(t) && t.function.name === toolCall.name,
+      );
       return tool && hasExecuteFunction(tool);
     });
   }
 
   private isManualToolCall(item: models.OutputFunctionCallItem): boolean {
-    const tool = this.options.tools?.find((t) => t.function.name === item.name);
+    const tool = this.options.tools?.find((t) => isClientTool(t) && t.function.name === item.name);
     return !!tool && !hasExecuteFunction(tool);
   }
 
@@ -595,7 +623,7 @@ export class ModelResult<
     turnContext: TurnContext,
   ): Promise<UnsentToolResult<TTools>[]> {
     const toolCallPromises = toolCalls.map(async (tc) => {
-      const tool = this.options.tools?.find((t) => t.function.name === tc.name);
+      const tool = this.options.tools?.find((t) => isClientTool(t) && t.function.name === tc.name);
       if (!tool || !hasExecuteFunction(tool)) {
         return null;
       }
@@ -717,7 +745,9 @@ export class ModelResult<
     turnContext: TurnContext,
   ): Promise<models.FunctionCallOutputItem[]> {
     const toolCallPromises = toolCalls.map(async (toolCall) => {
-      const tool = this.options.tools?.find((t) => t.function.name === toolCall.name);
+      const tool = this.options.tools?.find(
+        (t) => isClientTool(t) && t.function.name === toolCall.name,
+      );
       if (!tool || !hasExecuteFunction(tool)) {
         return null;
       }
@@ -848,10 +878,22 @@ export class ModelResult<
           error: value.result.error.message,
         });
       } else if (value.tool.function.toModelOutput) {
-        // toModelOutput exists - call it (may throw, which surfaces the error)
+        // toModelOutput exists - call it (may throw, which surfaces the error).
+        // Arguments have already been validated upstream by the tool's Zod
+        // inputSchema (which must be a ZodObject), so the runtime shape is
+        // always a record here. The `Tool` union widening loses the specific
+        // InferToolInput type, so we re-narrow defensively — a non-record
+        // value here signals a real upstream bug we want surfaced, not a
+        // case to paper over with `{}`.
+        const rawArgs: unknown = value.toolCall.arguments;
+        if (!isRecord(rawArgs)) {
+          throw new Error(
+            `toolCall.arguments for "${value.toolCall.name}" must be an object after Zod validation, got ${rawArgs === null ? 'null' : Array.isArray(rawArgs) ? 'array' : typeof rawArgs}`,
+          );
+        }
         const modelOutputResult = await value.tool.function.toModelOutput({
           output: value.result.result,
-          input: value.toolCall.arguments,
+          input: rawArgs,
         });
         outputForModel =
           modelOutputResult.type === 'content'
@@ -1248,7 +1290,9 @@ export class ModelResult<
         continue;
       }
 
-      const tool = this.options.tools?.find((t) => t.function.name === toolCall.name);
+      const tool = this.options.tools?.find(
+        (t) => isClientTool(t) && t.function.name === toolCall.name,
+      );
       if (!tool || !hasExecuteFunction(tool)) {
         // Can't execute, create error result
         unsentResults.push(
@@ -1487,12 +1531,38 @@ export class ModelResult<
         // Execute tools
         const toolResults = await this.executeToolRound(currentToolCalls, turnContext);
 
+        // Server-tool output items are already-executed results in the
+        // response; collect them so toolResults presents a unified list.
+        const serverToolItems: ToolResultItem[] = [];
+        for (const item of currentResponse.output) {
+          if (!hasTypeProperty(item)) {
+            continue;
+          }
+          if (
+            item.type === 'message' ||
+            item.type === 'reasoning' ||
+            item.type === 'function_call'
+          ) {
+            continue;
+          }
+          // Everything else is a server-tool output item (web_search_call,
+          // image_generation_call, file_search_call, or generic
+          // OutputServerToolItem covering openrouter:datetime and any new
+          // SDK server tool types).
+          if (isServerToolResultItem(item)) {
+            serverToolItems.push(item);
+          }
+        }
+
         // Track execution round
         this.allToolExecutionRounds.push({
           round: currentRound,
           toolCalls: currentToolCalls,
           response: currentResponse,
-          toolResults,
+          toolResults: [
+            ...toolResults,
+            ...serverToolItems,
+          ],
         });
 
         // Save tool results to state
@@ -1642,7 +1712,35 @@ export class ModelResult<
    * - image_generation_call: Image generation operations
    * - function_call_output: Results from executed tools
    */
-  getItemsStream(): AsyncIterableIterator<StreamableOutputItem> {
+  getItemsStream(): AsyncIterableIterator<StreamableOutputItem<TTools>> {
+    // Build the allowed-item-type scope from the tools actually passed to
+    // callModel, mirroring the compile-time rules that produce
+    // StreamableOutputItem<TTools>. A runtime predicate then drops items
+    // whose type isn't reachable in the narrowed union. The predicate's
+    // claim (`item is StreamableOutputItem<TTools>`) is sound because:
+    //   - `allowed` is constructed from the same tools that produced TTools
+    //   - `OutputServerToolItem.type` is `string` (open), so any non-client
+    //     item type is structurally assignable to it, covering generic /
+    //     unmapped server-tool outputs.
+    const scope = this.computeItemStreamScope();
+
+    const isInScope = (item: StreamableOutputItem): item is StreamableOutputItem<TTools> => {
+      if (scope.acceptAll) {
+        return true;
+      }
+      if (scope.allowed.has(item.type)) {
+        return true;
+      }
+      if (
+        scope.acceptGenericServerItem &&
+        item.type !== 'function_call' &&
+        item.type !== 'function_call_output'
+      ) {
+        return true;
+      }
+      return false;
+    };
+
     return async function* (this: ModelResult<TTools>) {
       await this.initStream();
 
@@ -1653,7 +1751,11 @@ export class ModelResult<
       // No tools — stream single turn directly (no broadcaster needed)
       if (!this.options.tools?.length) {
         if (this.reusableStream) {
-          yield* buildItemsStream(this.reusableStream);
+          for await (const item of buildItemsStream(this.reusableStream)) {
+            if (isInScope(item)) {
+              yield item;
+            }
+          }
         }
         return;
       }
@@ -1667,7 +1769,9 @@ export class ModelResult<
       for await (const event of consumer) {
         // Tool call outputs → yield directly as function_call_output items
         if (isToolCallOutputEvent(event)) {
-          yield event.output;
+          if (isInScope(event.output)) {
+            yield event.output;
+          }
           continue;
         }
 
@@ -1684,7 +1788,7 @@ export class ModelResult<
           const handler = itemsStreamHandlers[event.type];
           if (handler) {
             const result = handler(event as models.StreamEvents, itemsInProgress);
-            if (result) {
+            if (result && isInScope(result)) {
               yield result;
             }
           }
@@ -1693,6 +1797,87 @@ export class ModelResult<
 
       await executionPromise;
     }.call(this);
+  }
+
+  /**
+   * Compute the runtime allow-list of item types that `getItemsStream()`
+   * may yield, derived from the tools actually passed to callModel. The
+   * three return modes correspond to the compile-time narrowing:
+   *
+   * - `acceptAll: true` — no tools or fully-unconstrained TTools; the
+   *   yielded union is the widest `StreamableOutputItem`.
+   * - Specific `allowed` set — client tools contribute
+   *   `function_call` / `function_call_output`; mapped server tools
+   *   contribute their SDK output item type literal
+   *   (`web_search_call`, `file_search_call`, `image_generation_call`).
+   * - `acceptGenericServerItem: true` — at least one server tool has a
+   *   type the agent SDK does not have a dedicated output mapping for
+   *   (e.g. `openrouter:datetime`, `mcp`, new SDK additions). Any
+   *   non-client item type is accepted because these items pass through
+   *   as `OutputServerToolItem`, whose `type` field is an open `string`.
+   */
+  private computeItemStreamScope(): {
+    acceptAll: boolean;
+    allowed: ReadonlySet<string>;
+    acceptGenericServerItem: boolean;
+  } {
+    const tools = this.options.tools ?? [];
+    if (tools.length === 0) {
+      // No tools passed: runtime only emits message/reasoning, but the
+      // widest StreamableOutputItem<readonly Tool[]> includes every item
+      // type. Accept all so the default unconstrained case matches its
+      // compile-time union.
+      return {
+        acceptAll: true,
+        allowed: new Set(),
+        acceptGenericServerItem: false,
+      };
+    }
+    const allowed = new Set<string>([
+      'message',
+      'reasoning',
+    ]);
+    let acceptGenericServerItem = false;
+    for (const tool of tools) {
+      if (isClientTool(tool)) {
+        allowed.add('function_call');
+        allowed.add('function_call_output');
+        continue;
+      }
+      if (!isServerTool(tool)) {
+        continue;
+      }
+      const requestType = tool.config.type;
+      switch (requestType) {
+        case 'web_search':
+        case 'web_search_2025_08_26':
+        case 'web_search_preview':
+        case 'web_search_preview_2025_03_11':
+        case 'openrouter:web_search':
+          allowed.add('web_search_call');
+          break;
+        case 'file_search':
+          allowed.add('file_search_call');
+          break;
+        case 'image_generation':
+          allowed.add('image_generation_call');
+          break;
+        default:
+          // Unknown / generic server tool — at runtime its output items
+          // pass through as the request-type literal or as the SDK's
+          // OutputServerToolItem wrapper. Accept the literal plus the
+          // generic fallback. See `StreamableOutputItem` narrowing in
+          // stream-transformers.ts for the matching type-level rules.
+          allowed.add(requestType);
+          acceptGenericServerItem = true;
+          break;
+      }
+    }
+    return {
+      acceptAll: false,
+      allowed,
+      acceptGenericServerItem,
+    };
   }
 
   /**
@@ -1736,9 +1921,12 @@ export class ModelResult<
             yield item;
           }
         }
-        // Then yield the function_call_output results
+        // Then yield the function_call_output results (client tools only;
+        // server-tool output items are surfaced through getItemsStream).
         for (const toolResult of round.toolResults) {
-          yield toolResult;
+          if (isFunctionCallOutputItem(toolResult)) {
+            yield toolResult;
+          }
         }
       }
 

--- a/src/lib/next-turn-params.ts
+++ b/src/lib/next-turn-params.ts
@@ -1,5 +1,6 @@
 import type * as models from '@openrouter/sdk/models';
 import type { NextTurnParamsContext, ParsedToolCall, Tool } from './tool-types.js';
+import { isClientTool } from './tool-types.js';
 
 /**
  * Type guard to check if a value is a Record<string, unknown>
@@ -54,7 +55,8 @@ export async function executeNextTurnParamsFunctions(
   };
 
   for (const tool of tools) {
-    if (!tool.function.nextTurnParams) {
+    // Server tools have no client-side nextTurnParams hooks
+    if (!isClientTool(tool) || !tool.function.nextTurnParams) {
       continue;
     }
 

--- a/src/lib/stream-transformers.ts
+++ b/src/lib/stream-transformers.ts
@@ -190,36 +190,83 @@ export async function* buildResponsesMessageStream(
 }
 
 /**
+ * Narrowed SDK output item for a given response-side `type` literal.
+ * Picks the single `OutputItems` branch whose discriminant matches `T`.
+ */
+type OutputItemByType<T extends string> = Extract<
+  models.OutputItems,
+  {
+    type: T;
+  }
+>;
+
+/**
+ * Every server-tool output shape that is NOT a `*_call` output item.
+ * (These are emitted for OpenRouter-specific server tools like
+ * `openrouter:datetime`, `openrouter:web_search`, `openrouter:mcp`,
+ * etc.) Used as the fallback output shape for server tools without a
+ * dedicated mapping entry below.
+ */
+type OpenRouterServerToolOutput = Exclude<
+  models.OutputItems,
+  | {
+      type: 'message';
+    }
+  | {
+      type: 'reasoning';
+    }
+  | {
+      type: 'function_call';
+    }
+  | {
+      type: 'web_search_call';
+    }
+  | {
+      type: 'file_search_call';
+    }
+  | {
+      type: 'image_generation_call';
+    }
+>;
+
+/**
  * Maps server-tool request `type` literals to the SDK output item shape
- * emitted by that tool. Unmapped server-tool types fall back to the
- * generic `OutputServerToolItem`, so new SDK server tools type-check
- * (as the generic wrapper) with zero changes here.
+ * emitted by that tool. Entries resolve to the specific narrowed item
+ * from `OutputItems`. Unmapped server-tool types fall back to the union
+ * of all non-call server-tool output shapes (`OpenRouterServerToolOutput`),
+ * so new SDK server tools type-check with zero changes here.
  */
 type KnownServerToolOutputs = {
-  web_search_preview: models.OutputWebSearchCallItem;
-  web_search_preview_2025_03_11: models.OutputWebSearchCallItem;
-  web_search: models.OutputWebSearchCallItem;
-  web_search_2025_08_26: models.OutputWebSearchCallItem;
-  'openrouter:web_search': models.OutputWebSearchCallItem;
-  file_search: models.OutputFileSearchCallItem;
-  image_generation: models.OutputImageGenerationCallItem;
-  'openrouter:datetime': models.OutputServerToolItem;
+  web_search_preview: OutputItemByType<'web_search_call'>;
+  web_search_preview_2025_03_11: OutputItemByType<'web_search_call'>;
+  web_search: OutputItemByType<'web_search_call'>;
+  web_search_2025_08_26: OutputItemByType<'web_search_call'>;
+  // OpenRouter's web_search variant may emit either the standard
+  // `web_search_call` output OR the provider-specific `openrouter:web_search`
+  // output. Union both so consumers type-guard on `type` before accessing
+  // variant-specific fields.
+  'openrouter:web_search':
+    | OutputItemByType<'web_search_call'>
+    | OutputItemByType<'openrouter:web_search'>;
+  file_search: OutputItemByType<'file_search_call'>;
+  image_generation: OutputItemByType<'image_generation_call'>;
+  'openrouter:datetime': OutputItemByType<'openrouter:datetime'>;
   // code_interpreter | computer_use_preview | mcp | shell | apply_patch |
   //   local_shell | custom | any new SDK server-tool type → fall through
-  //   to OutputServerToolItem via InferServerToolOutput default.
+  //   to OpenRouterServerToolOutput via InferServerToolOutput default.
 };
 
 /**
  * Infer the output item shape for a given ServerTool. Known request types
- * map via KnownServerToolOutputs; anything else falls back to the generic
- * OutputServerToolItem (the SDK's catch-all wrapper for server tools it
- * hasn't carved out a dedicated output variant for).
+ * map via KnownServerToolOutputs; anything else falls back to the
+ * provider-side server-tool output union (`OpenRouterServerToolOutput`)
+ * so the SDK's forward-compat variants flow through automatically.
  */
 type InferServerToolOutput<S> =
   S extends ServerTool<infer K>
     ? K extends keyof KnownServerToolOutputs
       ? KnownServerToolOutputs[K]
-      : models.OutputServerToolItem
+      : OpenRouterServerToolOutput
     : never;
 
 /**
@@ -258,13 +305,14 @@ type WidestStreamableOutputItem =
   | models.OutputWebSearchCallItem // type: "web_search_call"
   | models.OutputFileSearchCallItem // type: "file_search_call"
   | models.OutputImageGenerationCallItem // type: "image_generation_call"
-  | models.OutputServerToolItem; // catch-all for new/generic server-tool items
+  | OpenRouterServerToolOutput; // every server-tool output the SDK exposes
+// plus its forward-compat `Unknown<"type">` catch-all
 
 /**
  * Narrowed streamable output union derived from the specific TTools passed.
  * `function_call` / `function_call_output` only appear if the array
  * contains client tools; server-tool output shapes are narrowed via
- * `KnownServerToolOutputs` with fallback to `OutputServerToolItem`.
+ * `KnownServerToolOutputs` with fallback to `OpenRouterServerToolOutput`.
  */
 type NarrowStreamableOutputItem<TTools extends readonly Tool[]> =
   | models.OutputMessage
@@ -371,20 +419,9 @@ function handleOutputItemAdded(
     };
   }
 
-  if (isWebSearchCallOutputItem(item)) {
-    return item;
-  }
-
-  if (isFileSearchCallOutputItem(item)) {
-    return item;
-  }
-
-  if (isImageGenerationCallOutputItem(item)) {
-    return item;
-  }
-
-  // Catch-all for any other server-tool output item (openrouter:datetime,
-  // generic OutputServerToolItem, or any new SDK server-tool output type).
+  // Catch-all for any other server-tool output item (web_search_call,
+  // file_search_call, image_generation_call, openrouter:datetime, generic
+  // OutputServerToolItem, or any new SDK server-tool output type).
   if (isServerToolResultItem(item)) {
     return item;
   }
@@ -511,19 +548,8 @@ function handleOutputItemDone(
     return item;
   }
 
-  if (isWebSearchCallOutputItem(item)) {
-    return item;
-  }
-
-  if (isFileSearchCallOutputItem(item)) {
-    return item;
-  }
-
-  if (isImageGenerationCallOutputItem(item)) {
-    return item;
-  }
-
-  // Catch-all for any other server-tool output item.
+  // Catch-all for any other server-tool output item (web_search_call,
+  // file_search_call, image_generation_call, or any other server-tool type).
   if (isServerToolResultItem(item)) {
     return item;
   }

--- a/src/lib/stream-transformers.ts
+++ b/src/lib/stream-transformers.ts
@@ -26,10 +26,11 @@ import {
   isResponseCompletedEvent,
   isResponseFailedEvent,
   isResponseIncompleteEvent,
+  isServerToolResultItem,
   isURLCitationAnnotation,
   isWebSearchCallOutputItem,
 } from './stream-type-guards.js';
-import type { ParsedToolCall, Tool } from './tool-types.js';
+import type { ClientTool, ParsedToolCall, ServerTool, Tool } from './tool-types.js';
 
 /**
  * Extract text deltas from responses stream events
@@ -189,18 +190,99 @@ export async function* buildResponsesMessageStream(
 }
 
 /**
- * Output item types that can be streamed from a response.
- * This is the union of all item types that appear in response output,
- * plus function_call_output for tool results.
+ * Maps server-tool request `type` literals to the SDK output item shape
+ * emitted by that tool. Unmapped server-tool types fall back to the
+ * generic `OutputServerToolItem`, so new SDK server tools type-check
+ * (as the generic wrapper) with zero changes here.
  */
-export type StreamableOutputItem =
+type KnownServerToolOutputs = {
+  web_search_preview: models.OutputWebSearchCallItem;
+  web_search_preview_2025_03_11: models.OutputWebSearchCallItem;
+  web_search: models.OutputWebSearchCallItem;
+  web_search_2025_08_26: models.OutputWebSearchCallItem;
+  'openrouter:web_search': models.OutputWebSearchCallItem;
+  file_search: models.OutputFileSearchCallItem;
+  image_generation: models.OutputImageGenerationCallItem;
+  'openrouter:datetime': models.OutputServerToolItem;
+  // code_interpreter | computer_use_preview | mcp | shell | apply_patch |
+  //   local_shell | custom | any new SDK server-tool type → fall through
+  //   to OutputServerToolItem via InferServerToolOutput default.
+};
+
+/**
+ * Infer the output item shape for a given ServerTool. Known request types
+ * map via KnownServerToolOutputs; anything else falls back to the generic
+ * OutputServerToolItem (the SDK's catch-all wrapper for server tools it
+ * hasn't carved out a dedicated output variant for).
+ */
+type InferServerToolOutput<S> =
+  S extends ServerTool<infer K>
+    ? K extends keyof KnownServerToolOutputs
+      ? KnownServerToolOutputs[K]
+      : models.OutputServerToolItem
+    : never;
+
+/**
+ * Union of output item shapes produced by the server tools present in
+ * `TTools`. For the default unconstrained `readonly Tool[]`, this widens
+ * to every mapped output plus the generic fallback. Unused otherwise.
+ */
+type InferServerToolOutputsUnion<TTools extends readonly Tool[]> = InferServerToolOutput<
+  Extract<TTools[number], ServerTool>
+>;
+
+/**
+ * True iff the tools array contains at least one client tool. Written as
+ * `true extends (distributed-check)` so distribution over a union yields
+ * `true` when any member matches (not `boolean`).
+ */
+type HasClientTool<TTools extends readonly Tool[]> = true extends (
+  TTools[number] extends ClientTool
+    ? true
+    : never
+)
+  ? true
+  : false;
+
+/**
+ * Widest possible streamable output — every item type the API can emit
+ * plus `function_call_output` that we construct for client tool results.
+ * Used as the default when `StreamableOutputItem` is referenced without
+ * a specific TTools.
+ */
+type WidestStreamableOutputItem =
   | models.OutputMessage // type: "message"
-  | models.OutputFunctionCallItem // type: "function_call"
   | models.OutputReasoningItem // type: "reasoning"
+  | models.OutputFunctionCallItem // type: "function_call"
+  | models.FunctionCallOutputItem // type: "function_call_output"
   | models.OutputWebSearchCallItem // type: "web_search_call"
   | models.OutputFileSearchCallItem // type: "file_search_call"
   | models.OutputImageGenerationCallItem // type: "image_generation_call"
-  | models.FunctionCallOutputItem; // type: "function_call_output" (tool results)
+  | models.OutputServerToolItem; // catch-all for new/generic server-tool items
+
+/**
+ * Narrowed streamable output union derived from the specific TTools passed.
+ * `function_call` / `function_call_output` only appear if the array
+ * contains client tools; server-tool output shapes are narrowed via
+ * `KnownServerToolOutputs` with fallback to `OutputServerToolItem`.
+ */
+type NarrowStreamableOutputItem<TTools extends readonly Tool[]> =
+  | models.OutputMessage
+  | models.OutputReasoningItem
+  | (HasClientTool<TTools> extends true
+      ? models.OutputFunctionCallItem | models.FunctionCallOutputItem
+      : never)
+  | InferServerToolOutputsUnion<TTools>;
+
+/**
+ * Output item types that can be streamed from a response. Parameterized
+ * on `TTools` so the yielded union reflects exactly which item types can
+ * appear given the tools passed. Call sites without a specific TTools
+ * receive the widest possible union (backward-compatible with the
+ * original pre-server-tools export).
+ */
+export type StreamableOutputItem<TTools extends readonly Tool[] = readonly Tool[]> =
+  readonly Tool[] extends TTools ? WidestStreamableOutputItem : NarrowStreamableOutputItem<TTools>;
 
 //#region ItemsStream Types and Handlers
 
@@ -298,6 +380,12 @@ function handleOutputItemAdded(
   }
 
   if (isImageGenerationCallOutputItem(item)) {
+    return item;
+  }
+
+  // Catch-all for any other server-tool output item (openrouter:datetime,
+  // generic OutputServerToolItem, or any new SDK server-tool output type).
+  if (isServerToolResultItem(item)) {
     return item;
   }
 
@@ -432,6 +520,11 @@ function handleOutputItemDone(
   }
 
   if (isImageGenerationCallOutputItem(item)) {
+    return item;
+  }
+
+  // Catch-all for any other server-tool output item.
+  if (isServerToolResultItem(item)) {
     return item;
   }
 

--- a/src/lib/stream-type-guards.ts
+++ b/src/lib/stream-type-guards.ts
@@ -110,26 +110,55 @@ export function isFunctionCallOutputItem(item: unknown): item is models.Function
 }
 
 /**
- * Type guard: narrows a response output item to the server-tool result
- * branches of the SDK's `OutputItems` union (web_search_call,
- * file_search_call, image_generation_call, or the generic
- * `OutputServerToolItem` that covers openrouter:datetime and any new
- * server-tool type added upstream without a dedicated SDK variant).
- *
- * Input is typed as `models.OutputItems` so the deny-list is sound: the
- * SDK union is finite, and excluding message/reasoning/function_call
- * leaves exactly the server-tool variants. Callers holding `unknown`
- * should use `hasTypeProperty` first to reach an `OutputItems`-shaped
- * value before invoking this guard.
+ * Client-owned output item `type` literals — the three variants we
+ * explicitly treat as NOT server-tool results. Server-tool variants are
+ * every other `OutputItems` discriminator, including the SDK's forward-
+ * compat `Unknown<"type">` catch-all. Listed as a named union so the
+ * assertion below can detect SDK drift (rename/removal).
  */
-export function isServerToolResultItem(
-  item: models.OutputItems,
-): item is
-  | models.OutputWebSearchCallItem
-  | models.OutputFileSearchCallItem
-  | models.OutputImageGenerationCallItem
-  | models.OutputServerToolItem {
-  return item.type !== 'message' && item.type !== 'reasoning' && item.type !== 'function_call';
+type ClientOutputItemType = 'message' | 'reasoning' | 'function_call';
+
+/**
+ * Compile-time check: each client-owned `type` literal must still be a
+ * member of `models.OutputItems['type']`. If the SDK renames `message`
+ * (etc.) or removes it, this check fails and forces the switch below to
+ * be updated rather than silently misclassifying the renamed variant.
+ */
+type _AssertClientTypesInSDK = ClientOutputItemType extends models.OutputItems['type']
+  ? true
+  : never;
+const _assertClientTypesInSDK = true satisfies _AssertClientTypesInSDK;
+void _assertClientTypesInSDK;
+
+/**
+ * Type guard: narrows a response output item to server-tool result
+ * variants — everything in `OutputItems` that is not `message`,
+ * `reasoning`, or `function_call`. Covers the SDK's per-tool output
+ * shapes (`OutputDatetimeItem`, `OutputWebSearchServerToolItem`,
+ * `OutputMcpServerToolItem`, etc.) and its forward-compat
+ * `Unknown<"type">` catch-all for unrecognized discriminators.
+ *
+ * The module-level `_AssertClientTypesInSDK` check fails if the SDK
+ * renames or drops one of the three client discriminators — blocking
+ * silent misclassification.
+ */
+export function isServerToolResultItem(item: models.OutputItems): item is Exclude<
+  models.OutputItems,
+  {
+    type: ClientOutputItemType;
+  }
+> {
+  switch (item.type) {
+    case 'message':
+    case 'reasoning':
+    case 'function_call':
+      return false;
+    default:
+      // Every remaining variant — per-tool server output (web_search_call,
+      // openrouter:datetime, openrouter:mcp, etc.) and the SDK's Unknown
+      // catch-all — is treated as a server-tool result.
+      return true;
+  }
 }
 
 // Content part type guards

--- a/src/lib/stream-type-guards.ts
+++ b/src/lib/stream-type-guards.ts
@@ -98,6 +98,40 @@ export function isImageGenerationCallOutputItem(
   );
 }
 
+/**
+ * Type guard for client function-call output items — the input-side items
+ * we construct and send back to the API after executing a client tool.
+ */
+export function isFunctionCallOutputItem(item: unknown): item is models.FunctionCallOutputItem {
+  if (typeof item !== 'object' || item === null || !('type' in item)) {
+    return false;
+  }
+  return item.type === 'function_call_output';
+}
+
+/**
+ * Type guard: narrows a response output item to the server-tool result
+ * branches of the SDK's `OutputItems` union (web_search_call,
+ * file_search_call, image_generation_call, or the generic
+ * `OutputServerToolItem` that covers openrouter:datetime and any new
+ * server-tool type added upstream without a dedicated SDK variant).
+ *
+ * Input is typed as `models.OutputItems` so the deny-list is sound: the
+ * SDK union is finite, and excluding message/reasoning/function_call
+ * leaves exactly the server-tool variants. Callers holding `unknown`
+ * should use `hasTypeProperty` first to reach an `OutputItems`-shaped
+ * value before invoking this guard.
+ */
+export function isServerToolResultItem(
+  item: models.OutputItems,
+): item is
+  | models.OutputWebSearchCallItem
+  | models.OutputFileSearchCallItem
+  | models.OutputImageGenerationCallItem
+  | models.OutputServerToolItem {
+  return item.type !== 'message' && item.type !== 'reasoning' && item.type !== 'function_call';
+}
+
 // Content part type guards
 
 export function isOutputTextPart(part: unknown): part is models.ResponseOutputText {

--- a/src/lib/tool-executor.ts
+++ b/src/lib/tool-executor.ts
@@ -1,16 +1,23 @@
+import type * as models from '@openrouter/sdk/models';
 import * as z4 from 'zod/v4';
 import type { $ZodObject, $ZodShape, $ZodType } from 'zod/v4/core';
 import type { ToolContextStore } from './tool-context.js';
 import { buildToolExecuteContext } from './tool-context.js';
 import type {
   APITool,
+  ClientTool,
   ParsedToolCall,
   Tool,
   ToolExecuteContext,
   ToolExecutionResult,
   TurnContext,
 } from './tool-types.js';
-import { hasExecuteFunction, isGeneratorTool, isRegularExecuteTool } from './tool-types.js';
+import {
+  hasExecuteFunction,
+  isGeneratorTool,
+  isRegularExecuteTool,
+  isServerTool,
+} from './tool-types.js';
 
 // Re-export ZodError for convenience
 export const ZodError = z4.ZodError;
@@ -92,17 +99,27 @@ export function convertZodToJsonSchema(zodSchema: $ZodType): Record<string, unkn
 }
 
 /**
- * Convert tools to OpenRouter API format
- * Accepts readonly arrays for better type compatibility
+ * Convert tools to OpenRouter API format. Server tools pass their SDK-shaped
+ * config through untouched; client tools are packaged into the function-call
+ * shape. Return type widens to the SDK's full request-tool union so any new
+ * server-tool variant added upstream flows through automatically.
  */
-export function convertToolsToAPIFormat(tools: readonly Tool[]): APITool[] {
-  return tools.map((tool) => ({
-    type: 'function' as const,
-    name: tool.function.name,
-    description: tool.function.description || null,
-    strict: null,
-    parameters: convertZodToJsonSchema(tool.function.inputSchema),
-  }));
+export function convertToolsToAPIFormat(
+  tools: readonly Tool[],
+): Array<models.ResponsesRequestToolUnion> {
+  return tools.map((tool) => {
+    if (isServerTool(tool)) {
+      return tool.config;
+    }
+    const apiTool: APITool = {
+      type: 'function' as const,
+      name: tool.function.name,
+      description: tool.function.description || null,
+      strict: null,
+      parameters: convertZodToJsonSchema(tool.function.inputSchema),
+    };
+    return apiTool;
+  });
 }
 
 /**
@@ -156,7 +173,7 @@ export function parseToolCallArguments(argumentsString: string): unknown {
  */
 // biome-ignore lint: parameters match the internal API shape
 function buildExecuteCtx(
-  tool: Tool,
+  tool: ClientTool,
   turnContext: TurnContext,
   contextStore?: ToolContextStore,
   sharedSchema?: $ZodObject<$ZodShape>,
@@ -336,10 +353,13 @@ export async function executeTool(
 }
 
 /**
- * Find a tool by name in the tools array
+ * Find a client tool by name in the tools array. Server tools have no
+ * client-side name to match against and are skipped.
  */
-export function findToolByName(tools: Tool[], name: string): Tool | undefined {
-  return tools.find((tool) => tool.function.name === name);
+export function findToolByName(tools: Tool[], name: string): ClientTool | undefined {
+  return tools.find(
+    (tool): tool is ClientTool => !isServerTool(tool) && tool.function.name === name,
+  );
 }
 
 /**

--- a/src/lib/tool-types.ts
+++ b/src/lib/tool-types.ts
@@ -315,12 +315,96 @@ export type ManualTool<
 };
 
 /**
- * Union type of all enhanced tool types
+ * Union type of all client-executed tool shapes (function, generator, manual).
+ * These run in the user's process via the agent SDK's tool execution loop.
  */
-export type Tool =
+export type ClientTool =
   | ToolWithExecute<$ZodObject<$ZodShape>, $ZodType<unknown>>
   | ToolWithGenerator<$ZodObject<$ZodShape>, $ZodType<unknown>, $ZodType<unknown>>
   | ManualTool<$ZodObject<$ZodShape>, $ZodType<unknown>>;
+
+/**
+ * Config payload for an OpenRouter server-executed tool. Derived directly
+ * from the SDK's request-tool union so new server tools flow through with
+ * zero agent-SDK changes. Excludes the client `function` branch — only
+ * server-side variants remain.
+ */
+export type ServerToolConfig = Exclude<
+  models.ResponsesRequestToolUnion,
+  {
+    type: 'function';
+  }
+>;
+
+/**
+ * The discriminator literals for every server tool known to the SDK
+ * (e.g. `"web_search_2025_08_26"`, `"openrouter:datetime"`, `"image_generation"`).
+ */
+export type ServerToolType = ServerToolConfig['type'];
+
+/**
+ * Structural base type for every server tool. Interface extension (not a
+ * distributive conditional) is used so the narrow-T subtype assigns cleanly
+ * into the wide-T supertype via nominal inheritance — TypeScript treats
+ * `ServerTool<'web_search_2025_08_26'>` as a subtype of `ServerToolBase`
+ * without needing to reason about variance through `Extract<..., {type: T}>`.
+ *
+ * `Tool` uses `ServerToolBase` as its union member (rather than a generic
+ * `ServerTool` parameterized on a union) so specific `ServerTool<T>` values
+ * assign into `Tool[]` directly.
+ */
+export interface ServerToolBase {
+  readonly _brand: 'server-tool';
+  readonly config: ServerToolConfig;
+}
+
+/**
+ * A server-executed tool. OpenRouter runs the tool and returns an output
+ * item in the response — no execute function lives on the client. When
+ * the type parameter `T` is a specific literal, `config` narrows to the
+ * SDK shape for that tool. Because this interface `extends ServerToolBase`,
+ * any `ServerTool<T>` value is nominally assignable to `ServerToolBase`
+ * (and hence to `Tool`) regardless of `T`.
+ *
+ * @template T The specific server-tool type literal (narrows `config`).
+ */
+export interface ServerTool<T extends ServerToolType = ServerToolType> extends ServerToolBase {
+  readonly config: Extract<
+    ServerToolConfig,
+    {
+      type: T;
+    }
+  >;
+}
+
+/**
+ * Union of every tool kind accepted by `callModel({ tools: [...] })`:
+ * client function/generator/manual tools, or OpenRouter server tools.
+ * The server branch is the structural base; specific `ServerTool<T>`
+ * values flow in via interface extension.
+ */
+export type Tool = ClientTool | ServerToolBase;
+
+/**
+ * Server-tool output items that appear in `response.output`. The specific
+ * SDK types are listed so TypeScript can narrow on the `type` discriminator,
+ * and `OutputServerToolItem` is the catch-all the SDK uses for any server
+ * tool it hasn't carved out a specific type for — including new server
+ * tools added upstream (e.g. `openrouter:datetime`). New additions flow
+ * through the catch-all with zero changes here.
+ */
+export type ServerToolResultItem =
+  | models.OutputWebSearchCallItem
+  | models.OutputFileSearchCallItem
+  | models.OutputImageGenerationCallItem
+  | models.OutputServerToolItem;
+
+/**
+ * Unified tool-result item: either a client function output we construct
+ * and send back, or a server-tool output item from OpenRouter. Populated
+ * on `ModelResult.allToolExecutionRounds[].toolResults`.
+ */
+export type ToolResultItem = models.FunctionCallOutputItem | ServerToolResultItem;
 
 /**
  * Extracts the input type from a tool definition
@@ -408,9 +492,36 @@ export type InferToolEventsUnion<T extends readonly Tool[]> = {
 }[number];
 
 /**
+ * Type guard: discriminates server-executed tools from client tools.
+ *
+ * Relies on the `_brand` discriminator that `ServerToolBase` declares and
+ * `ClientTool` lacks. `'_brand' in tool` narrows the union to the server
+ * branch structurally, so `tool._brand` is reachable without a cast.
+ */
+export function isServerTool(tool: Tool): tool is ServerTool {
+  if (typeof tool !== 'object' || tool === null) {
+    return false;
+  }
+  if (!('_brand' in tool)) {
+    return false;
+  }
+  return tool._brand === 'server-tool';
+}
+
+/**
+ * Type guard: true if the tool is a client-executed tool (function, generator, or manual).
+ */
+export function isClientTool(tool: Tool): tool is ClientTool {
+  return !isServerTool(tool);
+}
+
+/**
  * Type guard to check if a tool has an execute function
  */
 export function hasExecuteFunction(tool: Tool): tool is ToolWithExecute | ToolWithGenerator {
+  if (isServerTool(tool)) {
+    return false;
+  }
   return 'execute' in tool.function && typeof tool.function.execute === 'function';
 }
 
@@ -418,6 +529,9 @@ export function hasExecuteFunction(tool: Tool): tool is ToolWithExecute | ToolWi
  * Type guard to check if a tool uses a generator (has eventSchema)
  */
 export function isGeneratorTool(tool: Tool): tool is ToolWithGenerator {
+  if (isServerTool(tool)) {
+    return false;
+  }
   return 'eventSchema' in tool.function;
 }
 
@@ -432,6 +546,9 @@ export function isRegularExecuteTool(tool: Tool): tool is ToolWithExecute {
  * Type guard to check if a tool is a manual tool (no execute function)
  */
 export function isManualTool(tool: Tool): tool is ManualTool {
+  if (isServerTool(tool)) {
+    return false;
+  }
   return !('execute' in tool.function);
 }
 
@@ -695,8 +812,21 @@ export type ChatStreamEvent<TEvent = unknown> =
 export interface UnsentToolResult<TTools extends readonly Tool[] = readonly Tool[]> {
   /** The ID of the tool call this result is for */
   callId: string;
-  /** The name of the tool that was executed */
-  name: TTools[number]['function']['name'];
+  /** The name of the tool that was executed (client tools only) */
+  name: Extract<
+    TTools[number],
+    {
+      function: {
+        name: string;
+      };
+    }
+  > extends {
+    function: {
+      name: infer N;
+    };
+  }
+    ? N
+    : string;
   /** The output of the tool execution */
   output: unknown;
   /** Error message if the tool call was rejected or failed */
@@ -799,6 +929,9 @@ export type HasApprovalTools<TTools extends readonly Tool[]> = TTools extends re
  * Type guard to check if a tool has approval configured at runtime
  */
 export function toolHasApprovalConfigured(tool: Tool): boolean {
+  if (isServerTool(tool)) {
+    return false;
+  }
   const requireApproval = tool.function.requireApproval;
   return requireApproval === true || typeof requireApproval === 'function';
 }

--- a/src/lib/tool-types.ts
+++ b/src/lib/tool-types.ts
@@ -386,18 +386,26 @@ export interface ServerTool<T extends ServerToolType = ServerToolType> extends S
 export type Tool = ClientTool | ServerToolBase;
 
 /**
- * Server-tool output items that appear in `response.output`. The specific
- * SDK types are listed so TypeScript can narrow on the `type` discriminator,
- * and `OutputServerToolItem` is the catch-all the SDK uses for any server
- * tool it hasn't carved out a specific type for — including new server
- * tools added upstream (e.g. `openrouter:datetime`). New additions flow
- * through the catch-all with zero changes here.
+ * Server-tool output items that appear in `response.output`. Derived from
+ * the SDK's `OutputItems` union by removing the client-owned variants
+ * (message, reasoning, function_call). Every remaining branch — including
+ * server-tool-specific shapes like `OutputDatetimeItem`,
+ * `OutputWebSearchServerToolItem`, `OutputMcpServerToolItem`, and the
+ * SDK's forward-compat `Unknown<"type">` catch-all — flows through
+ * automatically when the SDK adds new server-tool variants.
  */
-export type ServerToolResultItem =
-  | models.OutputWebSearchCallItem
-  | models.OutputFileSearchCallItem
-  | models.OutputImageGenerationCallItem
-  | models.OutputServerToolItem;
+export type ServerToolResultItem = Exclude<
+  models.OutputItems,
+  | {
+      type: 'message';
+    }
+  | {
+      type: 'reasoning';
+    }
+  | {
+      type: 'function_call';
+    }
+>;
 
 /**
  * Unified tool-result item: either a client function output we construct
@@ -602,7 +610,29 @@ export interface StepResult<TTools extends readonly Tool[] = readonly Tool[]> {
   readonly stepType: 'initial' | 'continue';
   readonly text: string;
   readonly toolCalls: TypedToolCallUnion<TTools>[];
+  /**
+   * Client function tool results ONLY. Server-tool results
+   * (web_search_call, image_generation_call, file_search_call,
+   * openrouter:datetime, and other server-side tool output items) are NOT
+   * included here — see {@link StepResult.serverToolResults} for those.
+   */
   readonly toolResults: ToolExecutionResultUnion<TTools>[];
+  /**
+   * Server-side tool result items emitted by OpenRouter as part of the
+   * model response (e.g. `web_search_call`, `image_generation_call`,
+   * `file_search_call`, `openrouter:datetime`, and any other server-tool
+   * output variant in the SDK's `OutputItems` union).
+   *
+   * These results are produced by the provider rather than executed by
+   * the client, so they do not flow through the client `toolResults`
+   * array. Stop conditions that want to react to server-tool invocations
+   * (for example, stopping after the model performs a web search) should
+   * inspect this field.
+   *
+   * Optional for back-compat: earlier releases of this type did not
+   * populate server-tool results in step history.
+   */
+  readonly serverToolResults?: ServerToolResultItem[];
   readonly response: models.OpenResponsesResult;
   readonly usage?: models.Usage | null | undefined;
   readonly finishReason?: string | undefined;

--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -2,6 +2,9 @@ import type { $ZodObject, $ZodShape, $ZodType, infer as zodInfer } from 'zod/v4/
 import type {
   ManualTool,
   NextTurnParamsFunctions,
+  ServerTool,
+  ServerToolConfig,
+  ServerToolType,
   ToModelOutputFunction,
   Tool,
   ToolApprovalCheck,
@@ -333,6 +336,44 @@ export function tool(
   return {
     type: ToolType.Function,
     function: functionObj,
+  };
+}
+
+//#endregion
+
+//#region serverTool() Factory
+
+/**
+ * Creates an OpenRouter server-executed tool. OpenRouter runs the tool (web
+ * search, datetime, image generation, etc.) and returns the output item in
+ * the response — no client-side execute function is needed.
+ *
+ * The config shape is derived directly from the SDK's request-tool union
+ * (`models.ResponsesRequestToolUnion`) via `Exclude` + `Extract`, so new
+ * server-tool variants added upstream become valid here with zero changes
+ * in this SDK. Provide the `type` literal and the remaining fields narrow
+ * to match the chosen tool.
+ *
+ * @example
+ * ```typescript
+ * const tools = [
+ *   serverTool({ type: 'web_search_2025_08_26', engine: 'exa', maxResults: 10 }),
+ *   serverTool({ type: 'openrouter:datetime', parameters: { timezone: 'UTC' } }),
+ *   serverTool({ type: 'image_generation', size: '1024x1024', quality: 'high' }),
+ * ];
+ * ```
+ */
+export function serverTool<T extends ServerToolType>(
+  config: Extract<
+    ServerToolConfig,
+    {
+      type: T;
+    }
+  >,
+): ServerTool<T> {
+  return {
+    _brand: 'server-tool',
+    config,
   };
 }
 

--- a/tests/unit/has-approval-tools.test-d.ts
+++ b/tests/unit/has-approval-tools.test-d.ts
@@ -1,0 +1,111 @@
+/**
+ * Type-level tests for `HasApprovalTools` and `ToolHasApproval` when
+ * server tools are mixed into the tuple.
+ *
+ * Pre-existing limitation: the `tool()` factory widens the caller's
+ * `requireApproval: true` literal to `boolean`, so `ToolHasApproval`
+ * against factory-built tools falls through to `boolean`. These tests
+ * therefore exercise the type machinery directly against hand-rolled
+ * tool shapes, which is the only way to prove the recursive walk
+ * still behaves correctly when server tools appear alongside client
+ * tools. Server tools lack `function.requireApproval` entirely, so
+ * `ToolHasApproval<ServerTool>` resolves to `boolean` (the "uncertain"
+ * fallback) — importantly NOT to `true`, and the recursion does not
+ * short-circuit on their presence.
+ */
+
+import { expectTypeOf } from 'vitest';
+import type { $ZodObject, $ZodShape, $ZodType } from 'zod/v4/core';
+import type {
+  HasApprovalTools,
+  ManualTool,
+  ServerTool,
+  ToolHasApproval,
+  ToolWithExecute,
+} from '../../src/lib/tool-types.js';
+
+// Hand-rolled tool shapes that preserve the `requireApproval` literal
+// through the type system (the `tool()` factory widens it away).
+type ExplicitApproval = ToolWithExecute<$ZodObject<$ZodShape>, $ZodType<unknown>> & {
+  function: {
+    requireApproval: true;
+  };
+};
+type ExplicitNoApproval = ToolWithExecute<$ZodObject<$ZodShape>, $ZodType<unknown>> & {
+  function: {
+    requireApproval: false;
+  };
+};
+type UnknownApproval = ManualTool<$ZodObject<$ZodShape>, $ZodType<unknown>>;
+
+// --- Server tool on its own: never requires approval -------------------------
+expectTypeOf<ToolHasApproval<ServerTool<'openrouter:datetime'>>>().toEqualTypeOf<boolean>();
+expectTypeOf<
+  HasApprovalTools<
+    readonly [
+      ServerTool<'openrouter:datetime'>,
+    ]
+  >
+>().toEqualTypeOf<false>();
+expectTypeOf<
+  HasApprovalTools<
+    readonly [
+      ServerTool<'openrouter:datetime'>,
+      ServerTool<'web_search_2025_08_26'>,
+    ]
+  >
+>().toEqualTypeOf<false>();
+
+// --- Server tool + client tool with explicit approval: true ------------------
+expectTypeOf<
+  HasApprovalTools<
+    readonly [
+      ExplicitApproval,
+      ServerTool<'openrouter:datetime'>,
+    ]
+  >
+>().toEqualTypeOf<true>();
+expectTypeOf<
+  HasApprovalTools<
+    readonly [
+      ServerTool<'openrouter:datetime'>,
+      ExplicitApproval,
+    ]
+  >
+>().toEqualTypeOf<true>();
+expectTypeOf<
+  HasApprovalTools<
+    readonly [
+      ServerTool<'openrouter:datetime'>,
+      ExplicitApproval,
+      ServerTool<'web_search_2025_08_26'>,
+    ]
+  >
+>().toEqualTypeOf<true>();
+
+// --- Server tool + client tool with explicit non-approval: false -------------
+// `ToolHasApproval<ExplicitNoApproval>` resolves to `false`, so the recursion
+// moves on. With only server tools remaining the final answer is `false`.
+expectTypeOf<
+  HasApprovalTools<
+    readonly [
+      ExplicitNoApproval,
+      ServerTool<'openrouter:datetime'>,
+    ]
+  >
+>().toEqualTypeOf<false>();
+
+// --- Server tool + client tool with uncertain approval: recursion continues --
+// `ToolHasApproval<UnknownApproval>` is `boolean` (the fallback); recursion
+// proceeds to the server tool, which also yields `boolean`, final answer `false`.
+expectTypeOf<
+  HasApprovalTools<
+    readonly [
+      UnknownApproval,
+      ServerTool<'openrouter:datetime'>,
+    ]
+  >
+>().toEqualTypeOf<false>();
+
+// --- Sanity: empty tuple stays false -----------------------------------------
+expectTypeOf<HasApprovalTools<readonly []>>().toEqualTypeOf<false>();

--- a/tests/unit/server-tool-stream-narrowing.test-d.ts
+++ b/tests/unit/server-tool-stream-narrowing.test-d.ts
@@ -1,0 +1,96 @@
+/**
+ * Type-level narrowing fixtures for `StreamableOutputItem<TTools>`.
+ *
+ * No runtime assertions here — vitest's `expectTypeOf` reports mismatches
+ * at typecheck time. The purpose is to pin down what `getItemsStream()`
+ * yields given various tool configurations so a future regression (a
+ * widening of the default, a broken KnownServerToolOutputs map entry, or
+ * a drift in HasClientTool) surfaces as a type error, not a runtime bug.
+ */
+
+import type * as models from '@openrouter/sdk/models';
+import { expectTypeOf } from 'vitest';
+import { z } from 'zod/v4';
+import type { StreamableOutputItem } from '../../src/lib/stream-transformers.js';
+import { serverTool, tool } from '../../src/lib/tool.js';
+import type { ServerTool, ServerToolType, Tool } from '../../src/lib/tool-types.js';
+
+// --- Default (unconstrained TTools): widest possible union ------------------
+
+type Default = StreamableOutputItem;
+expectTypeOf<models.OutputMessage>().toExtend<Default>();
+expectTypeOf<models.OutputReasoningItem>().toExtend<Default>();
+expectTypeOf<models.OutputFunctionCallItem>().toExtend<Default>();
+expectTypeOf<models.FunctionCallOutputItem>().toExtend<Default>();
+expectTypeOf<models.OutputWebSearchCallItem>().toExtend<Default>();
+expectTypeOf<models.OutputFileSearchCallItem>().toExtend<Default>();
+expectTypeOf<models.OutputImageGenerationCallItem>().toExtend<Default>();
+expectTypeOf<models.OutputServerToolItem>().toExtend<Default>();
+
+// --- Explicit `readonly Tool[]`: same as default ----------------------------
+
+type AnyTools = StreamableOutputItem<readonly Tool[]>;
+expectTypeOf<models.OutputFunctionCallItem>().toExtend<AnyTools>();
+expectTypeOf<models.OutputWebSearchCallItem>().toExtend<AnyTools>();
+
+// --- Only a datetime server tool: narrow to message / reasoning / datetime --
+
+type DatetimeOnly = StreamableOutputItem<
+  readonly [
+    ServerTool<'openrouter:datetime'>,
+  ]
+>;
+expectTypeOf<models.OutputMessage>().toExtend<DatetimeOnly>();
+expectTypeOf<models.OutputReasoningItem>().toExtend<DatetimeOnly>();
+expectTypeOf<models.OutputServerToolItem>().toExtend<DatetimeOnly>();
+// Function items must NOT be in this narrowed union.
+expectTypeOf<models.OutputFunctionCallItem>().not.toExtend<DatetimeOnly>();
+expectTypeOf<models.FunctionCallOutputItem>().not.toExtend<DatetimeOnly>();
+// Web search specifically must NOT be in this narrowed union.
+expectTypeOf<models.OutputWebSearchCallItem>().not.toExtend<DatetimeOnly>();
+
+// --- One web_search + one client tool: function items appear, not image_gen -
+
+const datetimeT = serverTool({
+  type: 'openrouter:datetime',
+});
+const webSearchT = serverTool({
+  type: 'web_search_2025_08_26',
+  engine: 'exa',
+});
+const clientT = tool({
+  name: 'greet',
+  inputSchema: z.object({
+    name: z.string(),
+  }),
+  execute: ({ name }) => `hi ${name}`,
+});
+
+type MixedTools = readonly [
+  typeof webSearchT,
+  typeof clientT,
+];
+type Mixed = StreamableOutputItem<MixedTools>;
+expectTypeOf<models.OutputFunctionCallItem>().toExtend<Mixed>();
+expectTypeOf<models.FunctionCallOutputItem>().toExtend<Mixed>();
+expectTypeOf<models.OutputWebSearchCallItem>().toExtend<Mixed>();
+// image_generation wasn't in tools — its output should not be in the union.
+expectTypeOf<models.OutputImageGenerationCallItem>().not.toExtend<Mixed>();
+
+// --- Unknown/new-in-SDK server tool types fall back to OutputServerToolItem -
+
+type FutureToolOnly = StreamableOutputItem<
+  readonly [
+    ServerTool<ServerToolType>,
+  ]
+>;
+// The widest `ServerToolType` includes every known literal; the inferred
+// server-tool output union therefore includes OutputServerToolItem (the
+// catch-all). Any future SDK server-tool type literal added to the
+// `ServerToolConfig` union will flow through automatically.
+expectTypeOf<models.OutputServerToolItem>().toExtend<FutureToolOnly>();
+
+// Reference vars so nothing is unused.
+void datetimeT;
+void webSearchT;
+void clientT;

--- a/tests/unit/server-tool.test.ts
+++ b/tests/unit/server-tool.test.ts
@@ -1,0 +1,182 @@
+import type * as models from '@openrouter/sdk/models';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { z } from 'zod/v4';
+import { serverTool, tool } from '../../src/lib/tool.js';
+import { convertToolsToAPIFormat } from '../../src/lib/tool-executor.js';
+import type { ClientTool, ServerTool, Tool, ToolResultItem } from '../../src/lib/tool-types.js';
+import { isClientTool, isServerTool } from '../../src/lib/tool-types.js';
+
+describe('serverTool()', () => {
+  it('creates a branded ServerTool carrying the SDK config through', () => {
+    const t = serverTool({
+      type: 'web_search_2025_08_26',
+      engine: 'exa',
+      maxResults: 10,
+    });
+    expect(t._brand).toBe('server-tool');
+    expect(t.config.type).toBe('web_search_2025_08_26');
+    expect(isServerTool(t)).toBe(true);
+    expect(isClientTool(t)).toBe(false);
+  });
+
+  it('narrows config shape based on the chosen type literal', () => {
+    const dt = serverTool({
+      type: 'openrouter:datetime',
+      parameters: {
+        timezone: 'America/New_York',
+      },
+    });
+    // TS-level: dt.config is DatetimeServerTool — parameters.timezone typed as string
+    expect(dt.config.parameters?.timezone).toBe('America/New_York');
+
+    const img = serverTool({
+      type: 'image_generation',
+      size: '1024x1024',
+      quality: 'high',
+    });
+    expect(img.config.size).toBe('1024x1024');
+  });
+
+  it('rejects unknown server tool types at the type level', () => {
+    // Compile-time: passing an unknown `type` literal must error.
+    // @ts-expect-error unknown server tool type
+    serverTool({
+      type: 'totally-not-a-real-tool',
+    });
+  });
+
+  it('rejects wrong fields for a known type', () => {
+    // @ts-expect-error wrongField does not exist on web_search_2025_08_26 config
+    serverTool({
+      type: 'web_search_2025_08_26',
+      wrongField: 'x',
+    });
+  });
+});
+
+describe('convertToolsToAPIFormat', () => {
+  it('passes server tool configs through verbatim', () => {
+    const tools = [
+      serverTool({
+        type: 'openrouter:datetime',
+      }),
+      serverTool({
+        type: 'web_search_2025_08_26',
+        engine: 'native',
+      }),
+    ];
+    const api = convertToolsToAPIFormat(tools);
+    expect(api).toHaveLength(2);
+    expect(api[0]).toEqual({
+      type: 'openrouter:datetime',
+    });
+    expect(api[1]).toEqual({
+      type: 'web_search_2025_08_26',
+      engine: 'native',
+    });
+  });
+
+  it('shapes client tools into the function-call API format', () => {
+    const clientTool = tool({
+      name: 'echo',
+      inputSchema: z.object({
+        msg: z.string(),
+      }),
+      execute: ({ msg }) => msg,
+    });
+    const api = convertToolsToAPIFormat([
+      clientTool,
+    ]);
+    expect(api).toHaveLength(1);
+    const [fn] = api;
+    expect(fn).toMatchObject({
+      type: 'function',
+      name: 'echo',
+      description: null,
+    });
+  });
+
+  it('mixes client + server tools in one array', () => {
+    const clientTool = tool({
+      name: 'echo',
+      inputSchema: z.object({
+        msg: z.string(),
+      }),
+      execute: ({ msg }) => msg,
+    });
+    const tools = [
+      clientTool,
+      serverTool({
+        type: 'image_generation',
+        size: '1024x1024',
+      }),
+    ];
+    const api = convertToolsToAPIFormat(tools);
+    expect(api).toHaveLength(2);
+    expect(api[0]).toMatchObject({
+      type: 'function',
+      name: 'echo',
+    });
+    expect(api[1]).toMatchObject({
+      type: 'image_generation',
+      size: '1024x1024',
+    });
+  });
+});
+
+describe('type-level narrowing of guards', () => {
+  it('isServerTool narrows to ServerTool', () => {
+    const mix: Tool[] = [
+      tool({
+        name: 'x',
+        inputSchema: z.object({}),
+        execute: () => 1,
+      }),
+      serverTool({
+        type: 'openrouter:datetime',
+      }),
+    ];
+    for (const t of mix) {
+      if (isServerTool(t)) {
+        expectTypeOf(t).toExtend<ServerTool>();
+      } else {
+        expectTypeOf(t).toExtend<ClientTool>();
+      }
+    }
+  });
+});
+
+describe('ToolResultItem union', () => {
+  it('accepts client function outputs and server tool output shapes', () => {
+    const clientOutput: models.FunctionCallOutputItem = {
+      type: 'function_call_output',
+      callId: 'call_1',
+      output: 'result',
+    };
+    const webSearch: models.OutputWebSearchCallItem = {
+      type: 'web_search_call',
+      id: 'ws_1',
+      status: 'completed',
+      action: {
+        type: 'search',
+        query: 'hello',
+      },
+    };
+    const generic: models.OutputServerToolItem = {
+      type: 'openrouter:datetime',
+      status: 'completed',
+      additionalProperties: {
+        datetime: '2026-04-20T00:00:00Z',
+        timezone: 'UTC',
+      },
+    };
+
+    // Compile-time: all three must be assignable to ToolResultItem
+    const items: ToolResultItem[] = [
+      clientOutput,
+      webSearch,
+      generic,
+    ];
+    expect(items).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `serverTool()` factory for OpenRouter's server-executed tools (web_search, `openrouter:datetime`, image_generation, mcp, file_search, code_interpreter, computer_use, shell, apply_patch, custom). Configs pass through the SDK's `ResponsesRequestToolUnion` so new server tools added upstream work here with zero code changes.
- Unifies tool results: `ModelResult.allToolExecutionRounds[].toolResults` now holds both client `FunctionCallOutputItem`s and server-tool output items (`OutputWebSearchCallItem`, `OutputImageGenerationCallItem`, `OutputDatetimeItem`, `OutputMcpServerToolItem`, the SDK's `Unknown<"type">` catch-all, etc.) in one list discriminated by the SDK's `type` field. No `serverToolOutputs` side-channel.
- Narrows `getItemsStream()`'s yielded union based on the tools passed — `StreamableOutputItem<TTools>` uses a small `KnownServerToolOutputs` map for request→output type resolution and falls back to the SDK's server-tool output union for unmapped/new server tools. The narrowing is backed by a real runtime allow-list derived from `this.options.tools`, so the type claim corresponds to actual runtime behavior.
- Exposes server-tool outputs on `StepResult.serverToolResults` so `stopWhen` conditions can react to provider-side tool invocations (web search, image generation, etc.) instead of silently dropping them.
- Strict type safety throughout: zero `as` assertions added anywhere in the new code. `ServerTool` uses interface extension of `ServerToolBase` for nominal variance, the `isServerTool` guard narrows via `'_brand' in tool`, and arg re-validation in `toModelOutput` / `requireApproval` throws on non-record inputs instead of silently substituting `{}`.

## Example usage

### Calling the model with server tools

```typescript
import { callModel, serverTool, tool } from '@openrouter/agent';
import { z } from 'zod/v4';

// Mix server tools (run by OpenRouter) with client tools (run in your process).
const result = await callModel({
  client,
  request: {
    model: 'openai/gpt-4.1',
    input: 'What time is it in Tokyo, and summarize recent OpenRouter news.',
    tools: [
      serverTool({ type: 'openrouter:datetime', parameters: { timezone: 'Asia/Tokyo' } }),
      serverTool({ type: 'openrouter:web_search', parameters: { maxResults: 5 } }),
      tool({
        name: 'save_note',
        inputSchema: z.object({ title: z.string(), body: z.string() }),
        execute: async ({ title, body }) => ({ ok: await saveNote(title, body) }),
      }),
    ],
  },
});
```

`serverTool({ type })` accepts the exact SDK config shape for the chosen tool type — the remaining fields narrow to match `T` (e.g. `type: 'image_generation'` requires `size`, `quality`, etc.). An unknown `type` fails at compile time.

### Streaming unified outputs

```typescript
for await (const item of result.getItemsStream()) {
  switch (item.type) {
    case 'message':
      // assistant text (cumulative)
      break;
    case 'function_call':
    case 'function_call_output':
      // client tool call + our executed result
      break;
    case 'web_search_call':
      console.log('model searched:', item.action);
      break;
    case 'openrouter:datetime':
      console.log('datetime tool:', item.additionalProperties);
      break;
    // New/unknown server-tool outputs fall through here as
    // Unknown<"type"> without compile errors.
  }
}
```

`getItemsStream()` is typed on `TTools`, so only the item types reachable from the tools you passed appear in the union — `case 'image_generation_call'` won't typecheck if you didn't pass a server tool that produces it.

### Inspecting execution rounds

```typescript
await result.getResponse();

for (const round of result.allToolExecutionRounds) {
  for (const out of round.toolResults) {
    if (out.type === 'function_call_output') {
      // client tool result we executed and sent back
    } else if (out.type === 'web_search_call') {
      // provider-executed web search item
    } else if (out.type === 'openrouter:datetime') {
      // provider-executed datetime item
    }
  }
}
```

### Stop conditions with server tool results

```typescript
import type { StopCondition } from '@openrouter/agent';

// Stop as soon as the model performs a web search.
const stopOnWebSearch: StopCondition = ({ steps }) =>
  steps.some((s) => s.serverToolResults?.some((r) => r.type === 'web_search_call'));

const result = await callModel({
  client,
  request: {
    model: 'openai/gpt-4.1',
    input: '…',
    tools: [serverTool({ type: 'openrouter:web_search' })],
  },
  stopWhen: stopOnWebSearch,
});
```

`StepResult.toolResults` stays client-tool-centric (typed `ToolExecutionResultUnion<TTools>`); `StepResult.serverToolResults` carries the provider-side items. Both are populated per round.

### One tool call unlocks N tools (MCP)

A single `serverTool({ type: 'mcp', … })` entry in the `tools` array gives the model access to every tool exposed by the MCP server — no need to enumerate them up front, and no code changes when the server adds, removes, or renames tools. OpenRouter discovers the toolset, invokes the right one per turn, and emits one `openrouter:mcp` output item per invocation.

```typescript
import { callModel, serverTool } from '@openrouter/agent';

const result = await callModel({
  client,
  request: {
    model: 'openai/gpt-4.1',
    input: 'Find the most recent customer complaint in Gmail and draft a reply.',
    tools: [
      // ONE entry. The MCP server may expose 20+ tools (search_email,
      // get_thread, draft_reply, list_labels, …). The model picks per turn.
      serverTool({
        type: 'mcp',
        serverLabel: 'gmail',
        connectorId: 'connector_gmail',
        // Optional narrowing — omit to allow every tool the server exposes.
        allowedTools: ['search_email', 'get_thread', 'draft_reply'],
        requireApproval: 'never',
      }),
    ],
  },
});

// Each invocation surfaces as an openrouter:mcp output item with the
// specific tool name the model chose from the server's catalog.
for await (const item of result.getItemsStream()) {
  if (item.type === 'openrouter:mcp') {
    console.log('mcp invoked:', item.serverLabel, '→', item.toolName, item.status);
  }
}
```

The same pattern works for `serverTool({ type: 'openrouter:tool_search', … })` — one config entry enables the model to search a tool registry on demand and invoke whichever tool matches the query, again emitting one server-tool output item per call.

## Test plan

- [x] `pnpm tsc --noEmit` — clean against `@openrouter/sdk@^0.12.12`
- [x] `pnpm biome check src tests` — clean
- [x] `pnpm vitest run --project=unit` — 20 files, 246 tests pass, no type errors
- [x] CI green on `add-server-tools`: lint, typecheck, unit-tests, e2e-tests
- [x] New `tests/unit/server-tool.test.ts` — 9 runtime/type tests for the factory, conversion branching, guard narrowing, and `ToolResultItem` union
- [x] New `tests/unit/server-tool-stream-narrowing.test-d.ts` — type-level fixtures proving `getItemsStream()` yields exactly the right union per TTools (default widest, only-datetime narrows away `function_call` + `web_search_call`, etc.)
- [x] New `tests/unit/has-approval-tools.test-d.ts` — type-level coverage for `HasApprovalTools` / `ToolHasApproval` with server + client tools interleaved
- [ ] E2E: add an API-key-gated test exercising `serverTool({ type: 'openrouter:datetime' })` alongside a client tool end-to-end (follow-up)

## Notable design notes

- `ServerTool<T>` is an `interface ... extends ServerToolBase` (not a distributive conditional). Interface extension gives TypeScript the nominal subtyping it needs to assign `ServerTool<'web_search_2025_08_26'>` into `Tool[]` without variance issues, and lets `serverTool()` be a plain `return { _brand, config }`.
- Types are derived from the SDK wherever possible: `ServerToolConfig = Exclude<models.ResponsesRequestToolUnion, { type: 'function' }>`; `ServerToolType = ServerToolConfig['type']`; `InferServerToolOutput` maps each `T` via a small known-outputs table (`Extract<OutputItems, { type: T }>`) with the non-`*_call` portion of `OutputItems` as the catch-all. Adding a new server tool upstream requires zero changes here; mapping it to a specific SDK output shape is a one-line addition to `KnownServerToolOutputs`.
- Approval / `requireApproval` / `nextTurnParams` / `contextSchema` / `toModelOutput` intentionally do not apply to server tools (they have no client execution phase). All internal code paths for those features now guard with `isClientTool` / `isServerTool` so server tools flow through the executor without touching any of that machinery.

