### PR TITLE
Handle bundled ReadableStream responses in ModelResult

### DIFF
--- a/packages/agent/src/lib/model-result.ts
+++ b/packages/agent/src/lib/model-result.ts
@@ -93,16 +93,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 /**
  * Type guard for stream event with toReadableStream method
- * Checks constructor name, prototype, and method availability
+ * Checks ReadableStream inheritance and method availability
  */
 function isEventStream(value: unknown): value is EventStream<models.StreamEvents> {
   if (value === null || typeof value !== 'object') {
     return false;
   }
 
-  // Check constructor name for EventStream
-  const constructorName = Object.getPrototypeOf(value)?.constructor?.name;
-  if (constructorName === 'EventStream') {
+  if (typeof ReadableStream !== 'undefined' && value instanceof ReadableStream) {
     return true;
   }
 


### PR DESCRIPTION
## Summary
   - the agent package was failing when deployed to a production OpenNext Cloudflare Worker deployment (even though it worked fine in local `workerd` workflow)
   - Removes the brittle `constructor.name === "EventStream"` check.
   - Adds a direct `value instanceof ReadableStream` inheritance check.

## Verified Repro

I verified the naming check with a fresh minimal OpenNext Cloudflare Worker project using:

- `next@16.2.4`
- `@opennextjs/cloudflare@1.19.5`
- `wrangler@4.87.0`
- `@openrouter/agent@0.4.0`

Minimal route:

```ts
import { OpenRouter, stepCountIs } from "@openrouter/agent";

export const runtime = "nodejs";

export async function GET() {
  const openrouter = new OpenRouter({
    apiKey: process.env.OPENROUTER_API_KEY,
  });

  const result = openrouter.callModel({
    model: process.env.OPENROUTER_MODEL || "google/gemini-3-flash-preview",
    input: "Reply with exactly: ok",
    instructions: "Return a very short answer.",
    stopWhen: stepCountIs(1),
  });

  const [text, response] = await Promise.all([
    result.getText(),
    result.getResponse(),
  ]);

  return Response.json({
    text,
    object: response.object,
  });
}
```

Deploying that project to Cloudflare Workers with real `OPENROUTER_API_KEY` and `OPENROUTER_MODEL` secrets returned:

```txt
HTTP/2 500
```

`wrangler tail` showed:

```txt
Error: Unexpected response type from API
```

Expected result:

```json
{
  "text": "ok",
  "object": "response"
}
```

With this diff as a local patch, it succeeded. 
