### PR TITLE
Use getReader for stream shape checks

### DIFF
--- a/.changeset/curvy-streams-watch.md
+++ b/.changeset/curvy-streams-watch.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/agent": patch
+---
+
+Detect streamed Responses API results by readable stream behavior instead of constructor names or unsupported adapters.

--- a/packages/agent/src/lib/model-result.ts
+++ b/packages/agent/src/lib/model-result.ts
@@ -92,8 +92,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Type guard for stream event with toReadableStream method
- * Checks constructor name, prototype, and method availability
+ * Type guard for stream event responses
+ * Checks constructor name and readable stream behavior
  */
 function isEventStream(value: unknown): value is EventStream<models.StreamEvents> {
   if (value === null || typeof value !== 'object') {
@@ -106,11 +106,10 @@ function isEventStream(value: unknown): value is EventStream<models.StreamEvents
     return true;
   }
 
-  // Fallback: check for toReadableStream method (may be on prototype)
   const maybeStream = value as {
-    toReadableStream?: unknown;
+    getReader?: unknown;
   };
-  return typeof maybeStream.toReadableStream === 'function';
+  return typeof maybeStream.getReader === 'function';
 }
 
 export interface GetResponseOptions<
@@ -432,14 +431,11 @@ export class ModelResult<
 
   /**
    * Type guard to check if a value is a non-streaming response
-   * Only requires 'output' field and absence of 'toReadableStream' method
+   * Only requires 'output' field and absence of readable stream behavior
    */
   private isNonStreamingResponse(value: unknown): value is models.OpenResponsesResult {
     return (
-      value !== null &&
-      typeof value === 'object' &&
-      'output' in value &&
-      !('toReadableStream' in value)
+      value !== null && typeof value === 'object' && 'output' in value && !isEventStream(value)
     );
   }
 

--- a/packages/agent/src/lib/model-result.ts
+++ b/packages/agent/src/lib/model-result.ts
@@ -100,9 +100,7 @@ function isEventStream(value: unknown): value is EventStream<models.StreamEvents
     return false;
   }
 
-  // Check constructor name for EventStream
-  const constructorName = Object.getPrototypeOf(value)?.constructor?.name;
-  if (constructorName === 'EventStream') {
+  if (typeof ReadableStream !== 'undefined' && value instanceof ReadableStream) {
     return true;
   }
 

--- a/packages/agent/tests/unit/model-result-stream-detection.test.ts
+++ b/packages/agent/tests/unit/model-result-stream-detection.test.ts
@@ -1,0 +1,111 @@
+import type { OpenRouterCore } from '@openrouter/sdk/core';
+import type * as models from '@openrouter/sdk/models';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockBetaResponsesSend = vi.hoisted(() => vi.fn());
+
+vi.mock('@openrouter/sdk/funcs/betaResponsesSend', () => ({
+  betaResponsesSend: mockBetaResponsesSend,
+}));
+
+import { ModelResult } from '../../src/lib/model-result.js';
+
+function makeResponse(): models.OpenResponsesResult {
+  return {
+    id: 'resp_test_stream_detection',
+    object: 'response',
+    createdAt: 0,
+    model: 'test-model',
+    status: 'completed',
+    completedAt: 0,
+    output: [
+      {
+        id: 'msg_test_stream_detection',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [
+          {
+            type: 'output_text',
+            text: 'ok',
+            annotations: [],
+          },
+        ],
+      },
+    ],
+    error: null,
+    incompleteDetails: null,
+    temperature: null,
+    topP: null,
+    presencePenalty: null,
+    frequencyPenalty: null,
+    metadata: null,
+    instructions: null,
+    tools: [],
+    toolChoice: 'auto',
+    parallelToolCalls: false,
+  } as models.OpenResponsesResult;
+}
+
+function makeCompletedStream(
+  response: models.OpenResponsesResult,
+): ReadableStream<models.StreamEvents> {
+  return new ReadableStream<models.StreamEvents>({
+    start(controller) {
+      controller.enqueue({
+        type: 'response.completed',
+        response,
+        sequenceNumber: 0,
+      } as models.StreamEvents);
+      controller.close();
+    },
+  });
+}
+
+function makeResult(): ModelResult<[]> {
+  return new ModelResult({
+    request: {
+      model: 'test-model',
+      input: 'hello',
+    },
+    client: {} as OpenRouterCore,
+    tools: [],
+  });
+}
+
+describe('ModelResult stream detection', () => {
+  beforeEach(() => {
+    mockBetaResponsesSend.mockReset();
+  });
+
+  it('accepts ReadableStream responses whose constructor name is not EventStream', async () => {
+    const response = makeResponse();
+    const stream = makeCompletedStream(response);
+
+    expect(Object.getPrototypeOf(stream)?.constructor?.name).not.toBe('EventStream');
+    expect(stream).toBeInstanceOf(ReadableStream);
+
+    mockBetaResponsesSend.mockResolvedValue({
+      ok: true,
+      value: stream,
+    });
+
+    await expect(makeResult().getResponse()).resolves.toEqual(response);
+  });
+
+  it('rejects toReadableStream-only adapters before ReusableReadableStream reads them', async () => {
+    const response = makeResponse();
+    const adapter = {
+      toReadableStream: () => makeCompletedStream(response),
+    };
+
+    expect('getReader' in adapter).toBe(false);
+
+    mockBetaResponsesSend.mockResolvedValue({
+      ok: true,
+      value: adapter,
+    });
+
+    await expect(makeResult().getResponse()).rejects.toThrow('Unexpected response type from API');
+  });
+});


### PR DESCRIPTION
## Summary

Refactors `isEventStream` function to check for `getReader` instead of `toReadableStream`.

It also updates the non-streaming response guard to use the same stream-readability check.

## Why check for `getReader()` instead of `toReadableStream()`

This function gets used to check what gets passed into `ReusableReadableStream`. It later calls:

https://github.com/OpenRouterTeam/typescript-agent/blob/e3a868cfcc68eee699473e034f09d4efb7d6d41c/packages/agent/src/lib/reusable-stream.ts#L146

That means the actual runtime contract this typecheck is: “can the value passed downstream be invoked with `getReader()`?”

`toReadableStream()` seems to be a hallucination? I haven't found anything in the OpenRouter SDKs that either calls or provides `toReadableStream()`.

```ts
new ReusableReadableStream(apiResult.value);
```

So a value that only has `toReadableStream()` but does not itself have `getReader()` would pass the old guard and then fail later when `ReusableReadableStream` tries to read it.

### Testing

The unit tests cover the two response shapes that matter for this change:

- A real `ReadableStream` whose constructor name is not `EventStream`, matching bundled/minified runtimes such as OpenNext on Cloudflare Workers.
- An adapter-shaped object that only exposes `toReadableStream()` and does not expose `getReader()`, verifying it is rejected before reaching `ReusableReadableStream`.

Validation commands:

```bash
pnpm --filter @openrouter/agent lint
pnpm --filter @openrouter/agent typecheck
pnpm --filter @openrouter/agent test
```

I also verified this against a production Cloudflare Worker:

1. Build and pack `@openrouter/agent` from this PR branch.
2. Install the generated tarball into a minimal OpenNext Cloudflare Worker app using `next@16.2.4`, `@opennextjs/cloudflare@1.19.5`, and `wrangler@4.87.0`.
3. Confirm the compiled installed package contains the `ReadableStream` / `getReader()` guard and no constructor-name or `toReadableStream()` branch.
4. Deploy the worker with `opennextjs-cloudflare deploy`.
5. Set a real `OPENROUTER_API_KEY` Worker secret.
6. Call the deployed smoke route:

```bash
curl https://<worker-subdomain>/api/agent-smoke
```

Expected response:

```json
{"text":"ok","object":"response"}
```

Observed result from the deployed Worker:

```http
HTTP/2 200
```

```json
{"text":"ok","object":"response"}
```
