### PR TITLE
chore: add sentrux architectural gating

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,3 +90,23 @@ jobs:
             exit 0
           fi
           pnpm run test:e2e
+
+  structural-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Install sentrux
+        env:
+          SENTRUX_VERSION: v0.5.7
+        run: |
+          curl -fsSL \
+            "https://github.com/sentrux/sentrux/releases/download/${SENTRUX_VERSION}/sentrux-linux-x86_64" \
+            -o /usr/local/bin/sentrux
+          chmod +x /usr/local/bin/sentrux
+          sentrux --version
+
+      - name: Structural regression gate
+        run: sentrux gate

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sentrux": {
+      "command": "sentrux",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/.sentrux/baseline.json
+++ b/.sentrux/baseline.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": 1778026327.988928,
+  "quality_signal": 0.5194591550342765,
+  "coupling_score": 0.41732283464566927,
+  "cycle_count": 1,
+  "god_file_count": 0,
+  "hotspot_count": 0,
+  "complex_fn_count": 9,
+  "max_depth": 7,
+  "total_import_edges": 127,
+  "cross_module_edges": 55
+}

--- a/.sentrux/rules.toml
+++ b/.sentrux/rules.toml
@@ -1,0 +1,45 @@
+# Architectural rules enforced by `sentrux check` and `sentrux gate`.
+# Run from repo root: `sentrux check`
+
+[constraints]
+max_cycles = 0
+max_coupling = "B"
+max_cc = 15
+no_god_files = true
+
+# Layers: lower `order` = higher in the stack (may depend on higher-order
+# layers but not the other way around). Verified empirically — sentrux
+# flags "order N must not depend on order N+M" regardless of docs.
+
+[[layers]]
+name = "inner-loop"
+paths = ["packages/agent/src/inner-loop/*"]
+order = 0
+
+[[layers]]
+name = "lib"
+paths = ["packages/agent/src/lib/*"]
+order = 1
+
+[[layers]]
+name = "api-shape-helpers"
+paths = ["packages/agent/src/api-shape-helpers/*"]
+order = 2
+
+# Boundaries: explicit bans backing up the layer ordering.
+# `from` must not depend on `to`.
+
+[[boundaries]]
+from = "packages/agent/src/api-shape-helpers/*"
+to = "packages/agent/src/lib/*"
+reason = "api-shape-helpers holds leaf type definitions; it must not depend on lib."
+
+[[boundaries]]
+from = "packages/agent/src/api-shape-helpers/*"
+to = "packages/agent/src/inner-loop/*"
+reason = "api-shape-helpers is a leaf layer; it must not depend on anything above it."
+
+[[boundaries]]
+from = "packages/agent/src/lib/*"
+to = "packages/agent/src/inner-loop/*"
+reason = "lib is a utility layer; it must not depend on the inner-loop entry point."


### PR DESCRIPTION
## Summary

- Adds [sentrux](https://github.com/sentrux/sentrux) as the architectural quality sensor for this repo
- Ships a starter `.sentrux/rules.toml` + baseline that match today's code
- Wires a new `structural-gate` CI job that blocks PRs which regress structural metrics

## What's in this PR

### `.mcp.json`
Registers the sentrux MCP server at the repo root so any Claude Code session inside this checkout gets real-time structural feedback via MCP. Contributors need the sentrux binary installed locally (`brew install sentrux/tap/sentrux` or the Linux install script) for the MCP server to run.

### `.sentrux/rules.toml`
Encodes the package's current layering:

```
inner-loop  →  lib  →  api-shape-helpers
```

Verified by reading imports: `inner-loop/call-model.ts` imports from `lib/`; `lib/` files (`anthropic-compat`, `claude-type-guards`, `stream-transformers`) import from `api-shape-helpers/`; `api-shape-helpers/` is a leaf.

Constraints: `max_cycles=0`, `max_coupling="B"`, `max_cc=15`, `no_god_files=true`. Layer direction + three explicit boundary rules back up the layering.

> ⚠️ Layer `order` semantics in sentrux v0.5.7 are inverted relative to the public docs — `order=0` is highest in the stack. This is documented inline in the rules file.

### `.sentrux/baseline.json`
Snapshot of today's metrics (quality 5195, coupling 0.42, 1 cycle, 9 complex functions). `sentrux gate` compares against this; PRs that make any of these worse will fail CI.

### `.github/workflows/ci.yaml`
New `structural-gate` job. Installs `sentrux-linux-x86_64 v0.5.7` from GitHub Releases (pinned to the local version so baseline format stays aligned) and runs `sentrux gate`.

## What this PR deliberately does NOT do

- **Doesn't fix the pre-existing cycle in `src/lib/`** (11 files in a strongly-connected component). `sentrux check` surfaces it; `sentrux gate` locks it at 1 so it can't grow. Fixing is follow-up work.
- **Doesn't fix the 9 functions over cc=15** (worst: `convertToClaudeMessage` at 25). Same rationale — gate prevents regression, refactor is separate.
- **Doesn't tighten `max_coupling` below `B`.** Starter grade; tighten once we know the real coupling number and have taken one PR to adjust.

## Test plan

- [x] `sentrux check` run locally — passes layer + boundary rules, fails on the pre-existing cycle and cc violations (expected, gate is the blocker not check)
- [x] `sentrux gate` run locally against committed baseline — ✓ No degradation detected
- [x] `pnpm run lint && pnpm run typecheck` pass on this branch
- [ ] Verify the `structural-gate` CI job passes on this PR
- [ ] Verify the job correctly fails if someone opens a follow-up PR that adds a new cycle or pushes a cc-25+ function (manual smoke test)

## Follow-ups (not this PR)

1. Open issue: break the cycle across `src/lib/{async-params, conversation-state, item-types, model-result, next-turn-params, stop-conditions, stream-transformers, tool-context, tool-executor, tool-types, turn-context}.ts`.
2. Open issue: reduce cyclomatic complexity on the 9 functions listed by `sentrux check`.
3. After (1) and (2) land, re-run `sentrux gate --save` to tighten the baseline, then raise `max_coupling` toward A.