### PR TITLE
chore(release): @openrouter/agent 0.5.0 (HITL tools)

### DIFF
--- a/.changeset/curvy-streams-watch.md
+++ b/.changeset/curvy-streams-watch.md
@@ -1,5 +1,0 @@
----
-"@openrouter/agent": patch
----
-
-Detect streamed Responses API results by readable stream behavior instead of constructor names or unsupported adapters.

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,5 +1,43 @@
 # @openrouter/agent
 
+## 0.5.0
+
+### Minor Changes
+
+- Add human-in-the-loop (HITL) tool type, a new `ClientTool` variant that sits
+  between regular `execute` tools and `manual` tools. HITL tools define two
+  async hooks:
+
+  - `onToolCalled(input, context)` runs when the model invokes the tool.
+    Return a value to feed the model directly (like a regular `execute` tool),
+    or return `null` to pause the conversation so the caller can supply the
+    output later — the same flow used by manual tools.
+  - `onResponseReceived(rawResult, context)` runs on the next turn when an
+    incoming `function_call_output` matches a prior call of this tool. It lets
+    the caller transform or validate the raw response before it reaches the
+    model. Throwing surfaces as a tool error to the model.
+
+  HITL tools require an `outputSchema`, which is used to validate both the
+  `onToolCalled` return value (when non-null) and caller-supplied responses
+  (after any `onResponseReceived` transform, or as-is when no hook is defined).
+
+  New `ConversationStatus` value `'awaiting_hitl'` is emitted when one or more
+  HITL tools return `null` from `onToolCalled`, signaling that the caller
+  should resume with outputs for the paused calls.
+
+  New public exports:
+
+  - Types: `HITLTool`, `HITLToolFunction`
+  - Guards: `isHITLTool`, `isAutoResolvableTool` (true for execute / generator
+    / HITL tools — i.e. anything that can resolve within a turn)
+
+  `isManualTool` now returns `false` for HITL tools, so existing manual-tool
+  branches continue to behave correctly.
+
+### Patch Changes
+
+- [#34](https://github.com/OpenRouterTeam/typescript-agent/pull/34) [`61aca10`](https://github.com/OpenRouterTeam/typescript-agent/commit/61aca10fd9434fe69fbe1e069e4b1858613a7da7) Thanks [@w0nche0l](https://github.com/w0nche0l)! - Detect streamed Responses API results by readable stream behavior instead of constructor names or unsupported adapters.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/agent",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "OpenRouter",
   "description": "Agent toolkit for building AI applications with OpenRouter — tool orchestration, streaming, multi-turn conversations, and format compatibility.",
   "keywords": [


### PR DESCRIPTION
## Summary

Version-bump PR for `@openrouter/agent` from **0.4.0 → 0.5.0**. Consumes the
pre-existing pending changeset and adds a new one for the HITL feature.

- **Minor** — Human-in-the-loop tool type (from #38, merged without a changeset): new `HITLTool` / `HITLToolFunction`, guards `isHITLTool` + `isAutoResolvableTool`, `onToolCalled` / `onResponseReceived` hooks, and a new `'awaiting_hitl'` `ConversationStatus`. See `packages/agent/CHANGELOG.md` for the full entry.
- **Patch** — Stream detection regression coverage (from #34, via the pre-existing `curvy-streams-watch` changeset).

Code changes are limited to `packages/agent/package.json` (version) and
`packages/agent/CHANGELOG.md`. The `.changeset/curvy-streams-watch.md` file
is removed since `changeset version` consumed it.

## Test plan

- [ ] CI: build / typecheck / lint / unit + e2e tests pass
- [ ] Confirm `packages/agent/package.json` is `0.5.0`
- [ ] Confirm `packages/agent/CHANGELOG.md` includes both the HITL minor entry and the #34 patch entry
- [ ] On merge: tag + publish `@openrouter/agent@0.5.0` via whatever release workflow the repo uses