### PR TITLE
feat(agent): remove implicit 5-step cap in callModel

### DIFF
--- a/.changeset/remove-implicit-max-steps.md
+++ b/.changeset/remove-implicit-max-steps.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/agent": minor
+---
+
+Remove implicit 5-step cap in `callModel`. When `stopWhen` is omitted, the tool-execution loop now runs until the model produces a turn with no tool calls instead of stopping at 5 steps. Pass an explicit `stopWhen` (e.g. `stepCountIs(n)`, `maxCost(...)`, `maxTokensUsed(...)`) to bound iterations.

--- a/packages/agent/src/inner-loop/call-model.ts
+++ b/packages/agent/src/inner-loop/call-model.ts
@@ -64,7 +64,8 @@ export type { CallModelInput } from '../lib/async-params.js';
  * stopWhen: [stepCountIs(10), maxCost(0.50), hasToolCall('finalize')]
  * ```
  *
- * Default: `stepCountIs(5)` if not specified
+ * If `stopWhen` is omitted, the loop runs until the model produces a turn
+ * with no tool calls. Pass `stopWhen` to bound iterations, cost, or tokens.
  */
 export function callModel<
   TTools extends readonly Tool[],

--- a/packages/agent/src/lib/model-result.ts
+++ b/packages/agent/src/lib/model-result.ts
@@ -21,7 +21,7 @@ import {
   executeNextTurnParamsFunctions,
 } from './next-turn-params.js';
 import { ReusableReadableStream } from './reusable-stream.js';
-import { isStopConditionMet, stepCountIs } from './stop-conditions.js';
+import { isStopConditionMet } from './stop-conditions.js';
 import type { ItemInProgress, StreamableOutputItem } from './stream-transformers.js';
 import {
   buildItemsStream,
@@ -78,12 +78,6 @@ import {
   isServerTool,
   isToolCallOutputEvent,
 } from './tool-types.js';
-
-/**
- * Default maximum number of tool execution steps if no stopWhen is specified.
- * This prevents infinite loops in tool execution.
- */
-const DEFAULT_MAX_STEPS = 5;
 
 /**
  * Typeguard for plain-object records (non-null, non-array).
@@ -566,11 +560,16 @@ export class ModelResult<
    * Returns true if execution should stop.
    *
    * @remarks
-   * Default: stepCountIs(DEFAULT_MAX_STEPS) if no stopWhen is specified.
+   * When no `stopWhen` is specified, this returns false and execution stops
+   * only when the model produces a turn without tool calls. Pass an explicit
+   * `stopWhen` (e.g. `stepCountIs(n)`, `maxCost(...)`) to bound the loop.
    * This evaluates stop conditions against the complete step history.
    */
   private async shouldStopExecution(): Promise<boolean> {
-    const stopWhen = this.options.stopWhen ?? stepCountIs(DEFAULT_MAX_STEPS);
+    const { stopWhen } = this.options;
+    if (stopWhen === undefined) {
+      return false;
+    }
 
     const stopConditions = Array.isArray(stopWhen)
       ? stopWhen


### PR DESCRIPTION
## Summary
- Removed the implicit `stepCountIs(5)` fallback in `ModelResult.shouldStopExecution`. When `stopWhen` is omitted, the loop now runs until the model produces a turn with no tool calls.
- Dropped the now-unused `DEFAULT_MAX_STEPS` constant and `stepCountIs` import in `model-result.ts`.
- Updated `callModel` JSDoc to document the new default behavior.

## Why
The 5-step cap was an undocumented surprise — long tool-calling sessions silently stopped at 5 iterations. Bounds should be opt-in via `stopWhen` (`stepCountIs`, `maxCost`, `maxTokensUsed`, …), not a hidden default.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 280/280 unit tests pass
- [ ] e2e tests in CI

All existing tests already pass `stopWhen` explicitly, so behavior in tests is unchanged.