### PR TITLE
chore: version packages (0.6.0)

### DIFF
--- a/.changeset/remove-implicit-max-steps.md
+++ b/.changeset/remove-implicit-max-steps.md
@@ -1,5 +1,0 @@
----
-"@openrouter/agent": minor
----
-
-Remove implicit 5-step cap in `callModel`. When `stopWhen` is omitted, the tool-execution loop now runs until the model produces a turn with no tool calls instead of stopping at 5 steps. Pass an explicit `stopWhen` (e.g. `stepCountIs(n)`, `maxCost(...)`, `maxTokensUsed(...)`) to bound iterations.

--- a/.sentrux/baseline.json
+++ b/.sentrux/baseline.json
@@ -1,12 +1,12 @@
 {
-  "timestamp": 1778026327.988928,
-  "quality_signal": 0.5194591550342765,
-  "coupling_score": 0.41732283464566927,
+  "timestamp": 1778772814.945459,
+  "quality_signal": 0.5094207789931623,
+  "coupling_score": 0.42857142857142855,
   "cycle_count": 1,
   "god_file_count": 0,
   "hotspot_count": 0,
   "complex_fn_count": 9,
-  "max_depth": 7,
-  "total_import_edges": 127,
-  "cross_module_edges": 55
+  "max_depth": 8,
+  "total_import_edges": 133,
+  "cross_module_edges": 59
 }

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openrouter/agent
 
+## 0.6.0
+
+### Minor Changes
+
+- [#42](https://github.com/OpenRouterTeam/typescript-agent/pull/42) [`8e71f06`](https://github.com/OpenRouterTeam/typescript-agent/commit/8e71f06024f41e60ccdc68577016637a31912779) Thanks [@mattapperson](https://github.com/mattapperson)! - Remove implicit 5-step cap in `callModel`. When `stopWhen` is omitted, the tool-execution loop now runs until the model produces a turn with no tool calls instead of stopping at 5 steps. Pass an explicit `stopWhen` (e.g. `stepCountIs(n)`, `maxCost(...)`, `maxTokensUsed(...)`) to bound iterations.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/agent",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "OpenRouter",
   "description": "Agent toolkit for building AI applications with OpenRouter — tool orchestration, streaming, multi-turn conversations, and format compatibility.",
   "keywords": [


### PR DESCRIPTION
## Summary
- Bumps `@openrouter/agent` from `0.5.0` → `0.6.0`.
- Updates `packages/agent/CHANGELOG.md` with the `0.6.0` section.
- Consumes the changeset from #42 (removal of the implicit 5-step cap in `callModel`).

Generated by `pnpm changeset version`.

## Test plan
- [x] `pnpm changeset version` produced the version + CHANGELOG diff cleanly
- [ ] CI green (typecheck, lint, tests)
- [ ] Merge triggers publish to npm (if release workflow is wired)