### PR TITLE
ci: auto-bump @openrouter/sdk and dispatch monorepo on release

### DIFF
--- a/.github/scripts/bump-sdk.sh
+++ b/.github/scripts/bump-sdk.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# bump-sdk.sh — bump @openrouter/sdk in packages/agent and open the PR branch.
+#
+# Run by .github/workflows/bump-openrouter-sdk.yaml. Edits the dependency to the
+# caret floor of the target version, relocks, writes a changeset, closes any
+# prior bot bump PRs, commits, and pushes a new branch.
+#
+# Inputs (env):
+#   TARGET_VERSION  required — the @openrouter/sdk version to bump to
+#   GH_TOKEN        required — token with repo write (App token / PAT), so the
+#                   opened PR triggers Perry + CI (GITHUB_TOKEN would not)
+#
+# Outputs (written to $GITHUB_OUTPUT):
+#   branch  the pushed branch name (empty when noop)
+#   noop    "true" when already at target (no branch/PR needed)
+#
+# Read the value with `pnpm exec` is avoided on purpose — plain node/jq only.
+
+set -euo pipefail
+
+: "${TARGET_VERSION:?TARGET_VERSION is required}"
+
+REPO="OpenRouterTeam/typescript-agent"
+PKG_JSON="packages/agent/package.json"
+DEP="@openrouter/sdk"
+BRANCH_PREFIX="sdk-bot/bump-openrouter-sdk-"
+DESIRED_RANGE="^${TARGET_VERSION}"
+
+out() { echo "$1=$2" >> "${GITHUB_OUTPUT:-/dev/stdout}"; }
+
+# --- No-op guard: already at the desired caret floor? -----------------------
+CURRENT_RANGE="$(node -p "require('./${PKG_JSON}').dependencies['${DEP}']")"
+echo "Current ${DEP} range: ${CURRENT_RANGE} | desired: ${DESIRED_RANGE}"
+if [ "$CURRENT_RANGE" = "$DESIRED_RANGE" ]; then
+  echo "Already at ${DESIRED_RANGE} — nothing to do"
+  out noop true
+  out branch ""
+  exit 0
+fi
+
+# --- Edit the dependency range ----------------------------------------------
+node -e "
+  const fs = require('fs');
+  const p = './${PKG_JSON}';
+  const json = JSON.parse(fs.readFileSync(p, 'utf8'));
+  json.dependencies['${DEP}'] = '${DESIRED_RANGE}';
+  fs.writeFileSync(p, JSON.stringify(json, null, 2) + '\n');
+  console.log('Set ${DEP} to ${DESIRED_RANGE} in ${PKG_JSON}');
+"
+
+# --- Relock (FULL install; @openrouter/sdk is an onlyBuiltDependency) --------
+# A full install ensures pnpm-lock.yaml matches what the PR's own
+# `pnpm install --frozen-lockfile` CI step will expect.
+pnpm install --no-frozen-lockfile
+
+# --- Changeset (patch bump of @openrouter/agent) ----------------------------
+# Written directly rather than via `changeset add` so it is non-interactive and
+# deterministic. An empty changeset would not bump the version, so include the
+# package + summary explicitly.
+mkdir -p .changeset
+CHANGESET_FILE=".changeset/sdk-bump-$(date +%Y%m%d-%H%M%S).md"
+cat > "$CHANGESET_FILE" <<EOF
+---
+"@openrouter/agent": patch
+---
+
+Bump ${DEP} to ${TARGET_VERSION}
+EOF
+echo "Wrote changeset ${CHANGESET_FILE}"
+
+# --- Git identity + branch ---------------------------------------------------
+git config user.name 'OpenRouter SDK Bot'
+git config user.email 'sdk-bot@openrouter.ai'
+
+BRANCH="${BRANCH_PREFIX}$(date +%Y%m%d-%H%M%S)"
+
+# --- Close prior bot bump PRs (keep at most one open) ------------------------
+# Mirrors the close-prior pattern in openrouter-web's sdk-release-prs.yaml.
+PRIOR_JSON=$(gh pr list \
+  --repo "$REPO" \
+  --state open \
+  --search "head:${BRANCH_PREFIX}" \
+  --limit 500 \
+  --json number \
+  --jq '.[].number' || true)
+
+if [ -n "$PRIOR_JSON" ]; then
+  mapfile -t PRIOR <<< "$PRIOR_JSON"
+  echo "Closing ${#PRIOR[@]} prior bot bump PR(s) superseded by this run"
+  for N in "${PRIOR[@]}"; do
+    gh pr close "$N" --repo "$REPO" --delete-branch \
+      --comment "Superseded by a newer @openrouter/sdk bump" \
+      || echo "::warning::Failed to close PR #$N (continuing)"
+    sleep 1 # stay under GitHub secondary rate limits
+  done
+else
+  echo "No prior bot bump PRs to close"
+fi
+
+# --- Commit + push -----------------------------------------------------------
+git checkout -b "$BRANCH"
+git add "$PKG_JSON" pnpm-lock.yaml "$CHANGESET_FILE"
+git commit -m "chore: bump ${DEP} to ${TARGET_VERSION} [sdk-bot]"
+git push origin "$BRANCH"
+
+out noop false
+out branch "$BRANCH"
+echo "Pushed ${BRANCH}"

--- a/.github/scripts/pr-gate.sh
+++ b/.github/scripts/pr-gate.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# pr-gate.sh — poll a bump PR until Perry + CI reach a terminal state, then
+# squash-merge it (when AUTO_MERGE=true) or alert and leave it red.
+#
+# This is the self-gating auto-merge: GitHub-native `gh pr merge --auto` cannot
+# be relied on because the repo has no required status checks, so we poll the
+# verdict ourselves. The verdict mirrors ~/.claude/skills/get-pr-reviewed's
+# pr_status.sh — reimplemented here in pure gh + python3 (no Claude in the loop).
+#
+# Inputs (env):
+#   PR                required — PR number
+#   REPO              required — owner/name
+#   GH_TOKEN          required — token with merge permission
+#   AUTO_MERGE        "true" to merge on PASS; anything else = report-only
+#   SLACK_BOT_TOKEN   optional — Slack bot token for chat.postMessage
+#   SLACK_CHANNEL_ID  optional — Slack channel for alerts
+#   RUN_URL           optional — link back to this workflow run
+#
+# Exit: 0 on PASS (merged or report-only). Non-zero on FAIL/TIMEOUT so the run
+# surfaces red in the Actions UI.
+
+set -euo pipefail
+
+: "${PR:?PR is required}"
+: "${REPO:?REPO is required}"
+
+INTERVAL="${INTERVAL:-30}"
+TIMEOUT="${TIMEOUT:-1800}"      # 30 min overall
+PERRY_TIMEOUT="${PERRY_TIMEOUT:-480}" # 8 min for perry/review to appear at all
+SETTLE="${SETTLE:-45}"
+
+AI_REVIEWERS='perry/review|Devin Review|Graphite / AI Reviews|codex|claude'
+
+slack() {
+  # slack "<text>"
+  local text="$1"
+  if [ -z "${SLACK_BOT_TOKEN:-}" ] || [ -z "${SLACK_CHANNEL_ID:-}" ]; then
+    echo "(slack not configured; would have posted) $text"
+    return 0
+  fi
+  curl -fsS -X POST https://slack.com/api/chat.postMessage \
+    -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+    -H "Content-type: application/json; charset=utf-8" \
+    --data "$(python3 -c "import json,sys; print(json.dumps({'channel':sys.argv[1],'unfurl_links':False,'text':sys.argv[2]}))" "$SLACK_CHANNEL_ID" "$text")" \
+    >/dev/null || echo "::warning::Slack post failed (continuing)"
+}
+
+PR_URL="${GITHUB_SERVER_URL:-https://github.com}/${REPO}/pull/${PR}"
+
+# Returns one of: PASS PENDING FAIL_CI FAIL_REVIEWER, plus a reason line on
+# stderr. Reads checks + PR meta in two gh calls.
+verdict() {
+  local checks meta
+  checks="$(gh pr checks "$PR" -R "$REPO" --json name,state 2>/dev/null || echo '[]')"
+  meta="$(gh pr view "$PR" -R "$REPO" --json mergeable,reviewDecision 2>/dev/null || echo '{}')"
+  AI_REVIEWERS="$AI_REVIEWERS" python3 - "$checks" "$meta" <<'PY'
+import sys, json, os, re
+checks = json.loads(sys.argv[1])
+meta = json.loads(sys.argv[2])
+ai = re.compile(os.environ["AI_REVIEWERS"])
+FAIL = {"FAILURE","ERROR","CANCELLED","TIMED_OUT","ACTION_REQUIRED","STARTUP_FAILURE"}
+PENDING = {"PENDING","IN_PROGRESS","QUEUED","EXPECTED","WAITING"}
+PASS_REVIEW = {"SUCCESS","NEUTRAL","SKIPPED"}
+
+reasons = []
+ci_pending = False
+perry_present = False
+perry_terminal = False
+
+for c in checks:
+    name, state = c["name"], c["state"]
+    if ai.search(name):
+        if name == "perry/review":
+            perry_present = True
+            if state not in PENDING:
+                perry_terminal = True
+        if state not in PASS_REVIEW and state not in PENDING:
+            print(f"FAIL_REVIEWER", file=sys.stderr)
+            print(f"reviewer {name}={state}")
+            sys.exit(0)
+    else:
+        if state in FAIL:
+            print("FAIL_CI", file=sys.stderr)
+            print(f"CI {name}={state}")
+            sys.exit(0)
+        if state in PENDING:
+            ci_pending = True
+
+if meta.get("reviewDecision") == "CHANGES_REQUESTED":
+    print("FAIL_REVIEWER", file=sys.stderr)
+    print("reviewDecision=CHANGES_REQUESTED")
+    sys.exit(0)
+
+# Not failing. Decide PASS vs PENDING.
+if ci_pending:
+    print("PENDING", file=sys.stderr); print("CI still running"); sys.exit(0)
+if not (perry_present and perry_terminal):
+    print("PENDING", file=sys.stderr); print("waiting for perry/review"); sys.exit(0)
+if meta.get("mergeable") != "MERGEABLE":
+    print("PENDING", file=sys.stderr); print(f"mergeable={meta.get('mergeable')}"); sys.exit(0)
+print("PASS", file=sys.stderr); print("all green")
+PY
+}
+
+echo "Gating PR #${PR} on ${REPO} (timeout ${TIMEOUT}s, interval ${INTERVAL}s)"
+START=$(date +%s)
+LAST_REASON=""
+
+while :; do
+  NOW=$(date +%s); ELAPSED=$((NOW - START))
+
+  REASON="$(verdict 2>/tmp/gate.state)" || true
+  STATE="$(cat /tmp/gate.state)"
+  [ "$REASON" != "$LAST_REASON" ] && { echo "[$ELAPSED s] $STATE — $REASON"; LAST_REASON="$REASON"; }
+
+  case "$STATE" in
+    FAIL_CI|FAIL_REVIEWER)
+      slack ":x: @openrouter/sdk bump <${PR_URL}|PR #${PR}> blocked: ${REASON}. Left open for a human. <${RUN_URL:-$PR_URL}|run>"
+      echo "::error::PR #${PR} blocked: ${REASON}"
+      exit 1
+      ;;
+    PASS)
+      # Confirm once more after a short settle window so a momentary "all green"
+      # before a reviewer (re)posts cannot trip an early merge.
+      sleep "$SETTLE"
+      CONFIRM_REASON="$(verdict 2>/tmp/gate.state2)" || true
+      CONFIRM_STATE="$(cat /tmp/gate.state2)"
+      if [ "$CONFIRM_STATE" != "PASS" ]; then
+        echo "Settle re-check changed verdict to ${CONFIRM_STATE} (${CONFIRM_REASON}); continuing to poll"
+        LAST_REASON=""
+        continue
+      fi
+      if [ "${AUTO_MERGE:-false}" = "true" ]; then
+        echo "PASS — squash-merging PR #${PR}"
+        gh pr merge "$PR" -R "$REPO" --squash --delete-branch
+        slack ":white_check_mark: @openrouter/sdk bump <${PR_URL}|PR #${PR}> passed Perry + CI and was auto-merged."
+      else
+        echo "PASS (report-only; AUTO_MERGE!=true) — not merging PR #${PR}"
+        slack ":white_check_mark: @openrouter/sdk bump <${PR_URL}|PR #${PR}> is green and ready for merge."
+      fi
+      exit 0
+      ;;
+    PENDING)
+      # If perry/review never even shows up, the PR was likely opened with a
+      # token that doesn't trigger it — surface that rather than hang forever.
+      if [ "$REASON" = "waiting for perry/review" ] && [ "$ELAPSED" -ge "$PERRY_TIMEOUT" ]; then
+        slack ":warning: @openrouter/sdk bump <${PR_URL}|PR #${PR}>: perry/review never appeared after ${PERRY_TIMEOUT}s (token/app misconfig?). Not merging. <${RUN_URL:-$PR_URL}|run>"
+        echo "::error::perry/review did not appear within ${PERRY_TIMEOUT}s"
+        exit 1
+      fi
+      ;;
+  esac
+
+  if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+    slack ":warning: @openrouter/sdk bump <${PR_URL}|PR #${PR}> did not settle within ${TIMEOUT}s (last: ${REASON}). Not merging. <${RUN_URL:-$PR_URL}|run>"
+    echo "::error::Gate timed out after ${TIMEOUT}s (last: ${REASON})"
+    exit 1
+  fi
+  sleep "$INTERVAL"
+done

--- a/.github/workflows/bump-openrouter-sdk.yaml
+++ b/.github/workflows/bump-openrouter-sdk.yaml
@@ -37,18 +37,13 @@ jobs:
       noop: ${{ steps.bump.outputs.noop }}
       pr_number: ${{ steps.open.outputs.pr_number }}
     steps:
-      # An App token (or PAT) is required so the opened PR triggers Perry + CI.
-      # secrets.GITHUB_TOKEN would suppress downstream workflow runs.
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.AGENT_BUMP_APP_ID }}
-          private-key: ${{ secrets.AGENT_BUMP_APP_PRIVATE_KEY }}
-
+      # SUBTREE_PUSH_PAT (a PAT, not GITHUB_TOKEN) so the opened PR triggers
+      # Perry + CI — GITHUB_TOKEN would suppress those downstream runs. This is
+      # the org's established cross-repo PAT (the same one the monorepo uses to
+      # push into the SDK repos).
       - uses: actions/checkout@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.SUBTREE_PUSH_PAT }}
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
@@ -73,7 +68,7 @@ jobs:
         id: bump
         env:
           TARGET_VERSION: ${{ steps.ver.outputs.version }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.SUBTREE_PUSH_PAT }}
         run: |
           chmod +x .github/scripts/bump-sdk.sh
           ./.github/scripts/bump-sdk.sh
@@ -82,7 +77,7 @@ jobs:
         id: open
         if: steps.bump.outputs.noop != 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.SUBTREE_PUSH_PAT }}
         run: |
           set -euo pipefail
           PR_URL=$(gh pr create \
@@ -110,18 +105,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.AGENT_BUMP_APP_ID }}
-          private-key: ${{ secrets.AGENT_BUMP_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
 
       - name: Wait for Perry + CI, then merge or alert
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.SUBTREE_PUSH_PAT }}
           PR: ${{ needs.bump.outputs.pr_number }}
           REPO: OpenRouterTeam/typescript-agent
           AUTO_MERGE: ${{ github.event.inputs.dry_run != 'true' }}

--- a/.github/workflows/bump-openrouter-sdk.yaml
+++ b/.github/workflows/bump-openrouter-sdk.yaml
@@ -1,0 +1,133 @@
+name: Bump @openrouter/sdk
+
+# HOP A of the SDK release chain. Triggered by typescript-sdk after it publishes
+# a new @openrouter/sdk to npm. Opens a PR bumping the dependency in
+# packages/agent, lets Perry + CI run, then auto-merges on green (or alerts and
+# leaves the PR red on failure). Merging the PR feeds the changesets release
+# flow in publish.yaml, which cuts a new @openrouter/agent and dispatches HOP B.
+
+on:
+  repository_dispatch:
+    types: [openrouter-sdk-published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "@openrouter/sdk version to bump to (blank = npm latest)"
+        required: false
+        type: string
+      dry_run:
+        description: "Open the PR and run the gate, but do not merge"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: bump-openrouter-sdk
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.bump.outputs.branch }}
+      noop: ${{ steps.bump.outputs.noop }}
+      pr_number: ${{ steps.open.outputs.pr_number }}
+    steps:
+      # An App token (or PAT) is required so the opened PR triggers Perry + CI.
+      # secrets.GITHUB_TOKEN would suppress downstream workflow runs.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.AGENT_BUMP_APP_ID }}
+          private-key: ${{ secrets.AGENT_BUMP_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Resolve target version
+        id: ver
+        run: |
+          set -euo pipefail
+          V="${{ github.event.client_payload.version || github.event.inputs.version }}"
+          if [ -z "$V" ]; then
+            V="$(npm view @openrouter/sdk version)"
+          fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "Target @openrouter/sdk version: $V"
+
+      - name: Bump, relock, changeset, push branch
+        id: bump
+        env:
+          TARGET_VERSION: ${{ steps.ver.outputs.version }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          chmod +x .github/scripts/bump-sdk.sh
+          ./.github/scripts/bump-sdk.sh
+
+      - name: Open PR
+        id: open
+        if: steps.bump.outputs.noop != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          PR_URL=$(gh pr create \
+            --repo OpenRouterTeam/typescript-agent \
+            --base main \
+            --head "${{ steps.bump.outputs.branch }}" \
+            --title "chore: bump @openrouter/sdk to ${{ steps.ver.outputs.version }}" \
+            --body "$(cat <<'EOF'
+          Automated bump of `@openrouter/sdk` from the SDK release chain.
+
+          Source: ${{ github.event.client_payload.source_run_url || github.event.inputs.version && 'manual workflow_dispatch' }}
+
+          This PR will be auto-merged once Perry and CI pass. On failure it is
+          left open for a human. [sdk-bot]
+          EOF
+          )")
+          echo "Created $PR_URL"
+          echo "pr_number=$(echo "$PR_URL" | grep -oE '[0-9]+$')" >> "$GITHUB_OUTPUT"
+
+  gate:
+    needs: bump
+    if: needs.bump.outputs.noop != 'true' && needs.bump.outputs.pr_number != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.AGENT_BUMP_APP_ID }}
+          private-key: ${{ secrets.AGENT_BUMP_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+
+      - name: Wait for Perry + CI, then merge or alert
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ needs.bump.outputs.pr_number }}
+          REPO: OpenRouterTeam/typescript-agent
+          AUTO_MERGE: ${{ github.event.inputs.dry_run != 'true' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_BOT_TOKEN: ${{ secrets.CI_RELEASE_ALERT_SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.CI_RELEASE_ALERT_SLACK_CHANNEL_ID }}
+        run: |
+          chmod +x .github/scripts/pr-gate.sh
+          ./.github/scripts/pr-gate.sh

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -61,6 +61,7 @@ jobs:
       - run: pnpm run test
 
       - name: Version PR or Publish (changesets)
+        id: changesets
         if: >
           github.event_name == 'push' ||
           (github.event_name == 'workflow_dispatch' && inputs.mode == 'version')
@@ -73,6 +74,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Record the npm version before a manual publish so the dispatch step can
+      # tell whether this run actually published a new @openrouter/agent (the
+      # changesets/action `published` output only exists for the push /
+      # mode=version path, not this manual one).
+      - name: Capture pre-publish version (manual publish)
+        id: pre-publish
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'publish' && !inputs.dry-run
+        run: echo "version=$(npm view @openrouter/agent version)" >> "$GITHUB_OUTPUT"
 
       - name: Publish (workflow_dispatch, live)
         if: github.event_name == 'workflow_dispatch' && inputs.mode == 'publish' && !inputs.dry-run
@@ -90,3 +100,48 @@ jobs:
         run: pnpm -r publish --dry-run --access public --provenance --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # HOP B trigger: when @openrouter/agent is actually published, tell the
+      # monorepo (openrouter-web) to bump its pinned @openrouter/agent for
+      # server tools. Two publish paths produce a real publish:
+      #   1. changesets/action on push (Version PR merged) → `published` output
+      #   2. manual workflow_dispatch mode=publish → detect via npm version diff
+      - name: Resolve published @openrouter/agent version
+        id: published
+        if: ${{ !inputs.dry-run }}
+        run: |
+          set -euo pipefail
+          VERSION=""
+
+          # Path 1: changesets/action publish leg.
+          if [ "${{ steps.changesets.outputs.published }}" = "true" ]; then
+            VERSION=$(printf '%s' '${{ steps.changesets.outputs.publishedPackages }}' \
+              | python3 -c "import sys,json; pkgs=json.load(sys.stdin); print(next((p['version'] for p in pkgs if p['name']=='@openrouter/agent'), ''))")
+          fi
+
+          # Path 2: manual live publish — compare npm version before/after.
+          if [ -z "$VERSION" ] && [ -n "${{ steps.pre-publish.outputs.version }}" ]; then
+            AFTER="$(npm view @openrouter/agent version)"
+            if [ "$AFTER" != "${{ steps.pre-publish.outputs.version }}" ]; then
+              VERSION="$AFTER"
+            fi
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [ -n "$VERSION" ]; then
+            echo "Published @openrouter/agent $VERSION"
+          else
+            echo "No new @openrouter/agent publish detected — no dispatch"
+          fi
+
+      - name: Dispatch monorepo bump
+        if: ${{ !inputs.dry-run && steps.published.outputs.version != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.WEB_DISPATCH_PAT }}
+        run: |
+          set -euo pipefail
+          gh api repos/OpenRouterTeam/openrouter-web/dispatches \
+            -f event_type=openrouter-agent-published \
+            -F "client_payload[version]=${{ steps.published.outputs.version }}" \
+            -F "client_payload[source_run_url]=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "Dispatched openrouter-agent-published (version ${{ steps.published.outputs.version }}) to openrouter-web"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -137,7 +137,9 @@ jobs:
       - name: Dispatch monorepo bump
         if: ${{ !inputs.dry-run && steps.published.outputs.version != '' }}
         env:
-          GH_TOKEN: ${{ secrets.WEB_DISPATCH_PAT }}
+          # Reuse the org's cross-repo PAT; needs contents:write on
+          # OpenRouterTeam/openrouter-web to be accepted.
+          GH_TOKEN: ${{ secrets.SUBTREE_PUSH_PAT }}
         run: |
           set -euo pipefail
           gh api repos/OpenRouterTeam/openrouter-web/dispatches \


### PR DESCRIPTION
## Auto-bump `@openrouter/sdk` + dispatch monorepo on release (HOPs 2 & 3)

Receives the `openrouter-sdk-published` dispatch from `typescript-sdk`, opens a
PR bumping `@openrouter/sdk` in `packages/agent`, drives it through **Perry + CI**,
and **auto-merges on green**. When that release publishes a new `@openrouter/agent`,
it dispatches the monorepo to bump its server-tools pin.

### What this adds / changes
- **`.github/workflows/bump-openrouter-sdk.yaml`** (new): receiver +
  self-gating auto-merge.
  - `bump` job: opens the PR with **`SUBTREE_PUSH_PAT`** (a PAT, so Perry + CI
    run — `GITHUB_TOKEN` would suppress them), bumps the dependency to the caret
    floor `^<version>`, runs a full `pnpm install` relock, writes a changeset,
    and closes prior bot bump PRs.
  - `gate` job: polls `perry/review` + CI to a terminal state and squash-merges
    on green; on failure/blocker/timeout it alerts Slack and leaves the PR red
    (never merges red). Branch protection is off, so the gate — not GitHub-native
    auto-merge — does the gating.
- **`.github/scripts/bump-sdk.sh`**, **`.github/scripts/pr-gate.sh`** (new): the
  bump and wait-gate logic (locally runnable).
- **`.github/workflows/publish.yaml`** (extended): on a real `@openrouter/agent`
  publish (changesets `published` output, or an npm version diff on a manual
  publish), dispatch `openrouter-agent-published` to `openrouter-web` using
  `SUBTREE_PUSH_PAT`.

### Secrets — reuses existing, nothing new to create
- **`SUBTREE_PUSH_PAT`** — org's cross-repo PAT, used here to open + merge the
  bump PR and to dispatch the monorepo. ⚠️ Confirm its scope includes
  `contents: write` + `pull_requests: write` on **this repo** and
  `contents: write` on **`OpenRouterTeam/openrouter-web`**.
- **`CI_RELEASE_ALERT_SLACK_BOT_TOKEN` + `CI_RELEASE_ALERT_SLACK_CHANNEL_ID`** —
  org-level (already used by the monorepo's release workflows); the gate posts
  pass/fail here. No setup needed.
- **`NPM_TOKEN` / `OPENROUTER_API_KEY`** — already resolve org-level (the Release
  + CI workflows use them today). e2e coverage on bump PRs works out of the box.
- **Perry** is installed on this repo, so `perry/review` posts on the bump PR.

### How to test
1. Merge to `main`.
2. Actions → **Bump @openrouter/sdk** → Run workflow → `version=0.12.79`,
   `dry_run=true`. Confirm the PR opens, **Perry + CI run on it**, and the gate
   reports without merging.
3. Re-run with `dry_run=false` on a green PR to confirm squash-merge.

[sdk-bot]
