### PR TITLE
chore(agent): bump version to 0.7.1

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/agent",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "OpenRouter",
   "description": "Agent toolkit for building AI applications with OpenRouter — tool orchestration, streaming, multi-turn conversations, and format compatibility.",
   "keywords": [


### PR DESCRIPTION
## Summary
- Bumps `@openrouter/agent` package version from 0.7.0 to 0.7.1
- Build, typecheck, lint, and all 295 unit tests pass

## Test plan
- [x] `npm run build` — clean
- [x] `npm run typecheck` — no errors
- [x] `npm run lint` — no issues
- [x] `npm test` — 295/295 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)