### PR TITLE
ci: use GH_TOKEN for release-chain workflows

### DIFF
--- a/.github/workflows/bump-openrouter-sdk.yaml
+++ b/.github/workflows/bump-openrouter-sdk.yaml
@@ -37,13 +37,11 @@ jobs:
       noop: ${{ steps.bump.outputs.noop }}
       pr_number: ${{ steps.open.outputs.pr_number }}
     steps:
-      # SUBTREE_PUSH_PAT (a PAT, not GITHUB_TOKEN) so the opened PR triggers
-      # Perry + CI — GITHUB_TOKEN would suppress those downstream runs. This is
-      # the org's established cross-repo PAT (the same one the monorepo uses to
-      # push into the SDK repos).
+      # GH_TOKEN is a PAT (not the Actions GITHUB_TOKEN) so the opened PR
+      # triggers Perry + CI — GITHUB_TOKEN would suppress those downstream runs.
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.SUBTREE_PUSH_PAT }}
+          token: ${{ secrets.GH_TOKEN }}
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
@@ -68,7 +66,7 @@ jobs:
         id: bump
         env:
           TARGET_VERSION: ${{ steps.ver.outputs.version }}
-          GH_TOKEN: ${{ secrets.SUBTREE_PUSH_PAT }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           chmod +x .github/scripts/bump-sdk.sh
           ./.github/scripts/bump-sdk.sh
@@ -77,7 +75,7 @@ jobs:
         id: open
         if: steps.bump.outputs.noop != 'true'
         env:
-          GH_TOKEN: ${{ secrets.SUBTREE_PUSH_PAT }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           set -euo pipefail
           PR_URL=$(gh pr create \
@@ -109,7 +107,7 @@ jobs:
 
       - name: Wait for Perry + CI, then merge or alert
         env:
-          GH_TOKEN: ${{ secrets.SUBTREE_PUSH_PAT }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           PR: ${{ needs.bump.outputs.pr_number }}
           REPO: OpenRouterTeam/typescript-agent
           AUTO_MERGE: ${{ github.event.inputs.dry_run != 'true' }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -137,9 +137,9 @@ jobs:
       - name: Dispatch monorepo bump
         if: ${{ !inputs.dry-run && steps.published.outputs.version != '' }}
         env:
-          # Reuse the org's cross-repo PAT; needs contents:write on
-          # OpenRouterTeam/openrouter-web to be accepted.
-          GH_TOKEN: ${{ secrets.SUBTREE_PUSH_PAT }}
+          # Cross-repo PAT; needs contents:write on
+          # OpenRouterTeam/openrouter-web so the repository_dispatch is accepted.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           set -euo pipefail
           gh api repos/OpenRouterTeam/openrouter-web/dispatches \


### PR DESCRIPTION
## Use `GH_TOKEN` for the release-chain workflows

Follow-up to #49 (which merged before this rewire landed). Switches the
release-chain workflows on this repo from `SUBTREE_PUSH_PAT` to the dedicated
**`GH_TOKEN`** PAT now configured as a repo secret.

### What changes
- **`bump-openrouter-sdk.yaml`** — checkout `token:`, the bump-step `GH_TOKEN`,
  the open-PR `GH_TOKEN`, and the gate-step `GH_TOKEN` all now read
  `secrets.GH_TOKEN`. (Still a PAT, not the Actions `GITHUB_TOKEN`, so the
  opened bump PR triggers Perry + CI.)
- **`publish.yaml`** — the `openrouter-agent-published` dispatch to
  `openrouter-web` now uses `secrets.GH_TOKEN`.

### Secret requirement
- **`GH_TOKEN`** — set on this repo. For the `publish.yaml` dispatch to be
  accepted, this PAT must have **`contents: write` on
  `OpenRouterTeam/openrouter-web`** (the dispatch target), plus
  `contents`+`pull_requests: write` here.

Verified with `actionlint` (clean); no `SUBTREE_PUSH_PAT` references remain.

[sdk-bot]
