### PR TITLE
chore: bump @openrouter/sdk to 0.13.7

### DIFF
--- a/.changeset/bump-openrouter-sdk-0-13-7.md
+++ b/.changeset/bump-openrouter-sdk-0-13-7.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/agent": patch
+---
+
+Bump @openrouter/sdk to 0.13.7

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -116,7 +116,7 @@
     "compile": "tsc"
   },
   "dependencies": {
-    "@openrouter/sdk": "^0.12.12",
+    "@openrouter/sdk": "^0.13.7",
     "zod": "^4.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
   packages/agent:
     dependencies:
       '@openrouter/sdk':
-        specifier: ^0.12.12
-        version: 0.12.12
+        specifier: ^0.13.7
+        version: 0.13.7
       zod:
         specifier: ^4.0.0
         version: 4.3.6
@@ -351,8 +351,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@openrouter/sdk@0.12.12':
-    resolution: {integrity: sha512-/4FUsYEW82sff6/QtuY7NrIe2SLya/jv8HCk4VCYFXpHvr18P2osOn4iTwTqkqu4SJdrFtj9VTRKoBIg61u9dQ==}
+  '@openrouter/sdk@0.13.7':
+    resolution: {integrity: sha512-/QGoYdbFC2lqnVoCwtBX1+3Z5v6SF5hS1/dQisY0so3DzNAIQLHShA0OQVeAg20X0RG3CSKSCK0Ijnkt2rHDXA==}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
@@ -1407,7 +1407,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@openrouter/sdk@0.12.12':
+  '@openrouter/sdk@0.13.7':
     dependencies:
       zod: 4.3.6
 


### PR DESCRIPTION
Bumps `@openrouter/sdk` in `packages/agent` from `^0.12.12` to `^0.13.7` (latest on npm) and relocks `pnpm-lock.yaml`.

Includes a patch changeset for `@openrouter/agent`, so merging this will feed the Version Packages PR (bumping `0.7.1` → `0.7.2` + CHANGELOG) per the standard release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)