### PR TITLE
fix(agent): stop tool loop on unresolved manual tool calls instead of sending broken history

### DIFF
--- a/.changeset/orange-drinks-smile.md
+++ b/.changeset/orange-drinks-smile.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/agent': patch
+---
+
+Stop the tool-execution loop when a round contains unresolved manual (client-executed) tool calls, instead of sending a follow-up request whose input carries a `function_call` with no matching `function_call_output` — a history providers reject with a 400 "No tool output found for function call ...". The response is surfaced so the caller can execute the manual calls and continue, mirroring the existing all-manual behavior.

--- a/packages/agent/src/lib/model-result.ts
+++ b/packages/agent/src/lib/model-result.ts
@@ -2005,6 +2005,22 @@ export class ModelResult<
           return;
         }
 
+        // Manual (client-executed) tools produce no output this round —
+        // `executeToolRound` returns nothing for them — so a mixed round of
+        // auto-executed and manual calls would otherwise send a follow-up
+        // request whose input contains a `function_call` with no matching
+        // `function_call_output`. Providers reject that history with a 400
+        // ("No tool output found for function call ..."). Stop the loop and
+        // surface the response instead, so the caller can execute the manual
+        // calls and continue — mirroring the all-manual behavior of the
+        // `hasExecutableToolCalls` guards. Also covers calls to tool names
+        // not present in `options.tools` at all.
+        const resolvedCallIds = new Set(toolResults.map((r) => r.callId));
+        const hasUnresolvedToolCalls = currentToolCalls.some((tc) => !resolvedCallIds.has(tc.id));
+        if (hasUnresolvedToolCalls) {
+          break;
+        }
+
         // Apply nextTurnParams
         await this.applyNextTurnParams(currentToolCalls);
 

--- a/packages/agent/tests/unit/mixed-manual-tool-round.test.ts
+++ b/packages/agent/tests/unit/mixed-manual-tool-round.test.ts
@@ -1,0 +1,197 @@
+import type { OpenRouterCore } from '@openrouter/sdk/core';
+import type * as models from '@openrouter/sdk/models';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+const mockBetaResponsesSend = vi.hoisted(() => vi.fn());
+
+vi.mock('@openrouter/sdk/funcs/betaResponsesSend', () => ({
+  betaResponsesSend: mockBetaResponsesSend,
+}));
+
+import { callModel } from '../../src/inner-loop/call-model.js';
+import { ToolType } from '../../src/lib/tool-types.js';
+
+function functionCallItem(
+  callId: string,
+  name: string,
+  args: string,
+): models.OutputFunctionCallItem {
+  return {
+    type: 'function_call',
+    id: `fc_${callId}`,
+    callId,
+    name,
+    arguments: args,
+    status: 'completed',
+  };
+}
+
+function makeResponse(
+  id: string,
+  output: models.OpenResponsesResult['output'],
+): models.OpenResponsesResult {
+  return {
+    id,
+    object: 'response',
+    createdAt: 0,
+    model: 'test-model',
+    status: 'completed',
+    completedAt: 0,
+    output,
+    error: null,
+    incompleteDetails: null,
+    temperature: null,
+    topP: null,
+    presencePenalty: null,
+    frequencyPenalty: null,
+    metadata: null,
+    instructions: null,
+    tools: [],
+    toolChoice: 'auto',
+    parallelToolCalls: false,
+  } as models.OpenResponsesResult;
+}
+
+function textResponse(id: string, text: string): models.OpenResponsesResult {
+  return makeResponse(id, [
+    {
+      id: 'msg_text',
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [
+        {
+          type: 'output_text',
+          text,
+          annotations: [],
+        },
+      ],
+    },
+  ]);
+}
+
+const autoTool = {
+  type: ToolType.Function,
+  function: {
+    name: 'auto_search',
+    description: 'Auto-executed tool.',
+    inputSchema: z.object({
+      query: z.string(),
+    }),
+    outputSchema: z.object({
+      result: z.string(),
+    }),
+    execute: async (_params: { query: string }) => ({
+      result: 'found it',
+    }),
+  },
+} as const;
+
+// No `execute` — the client is responsible for running this tool.
+const manualTool = {
+  type: ToolType.Function,
+  function: {
+    name: 'exec_command',
+    description: 'Manual client-executed tool.',
+    inputSchema: z.object({
+      command: z.string(),
+    }),
+    outputSchema: z.object({
+      stdout: z.string(),
+    }),
+  },
+} as const;
+
+const client = {} as OpenRouterCore;
+
+describe('mixed auto + manual tool round', () => {
+  beforeEach(() => {
+    mockBetaResponsesSend.mockReset();
+  });
+
+  it('stops the loop instead of sending a follow-up with an orphaned function_call', async () => {
+    const mixedRoundResponse = makeResponse('resp_mixed', [
+      functionCallItem('call_auto_1', 'auto_search', '{"query":"docs"}'),
+      functionCallItem('call_manual_1', 'exec_command', '{"command":"ls"}'),
+    ]);
+
+    mockBetaResponsesSend.mockResolvedValueOnce({
+      ok: true,
+      value: mixedRoundResponse,
+    });
+
+    const result = callModel(client, {
+      model: 'test-model',
+      input: 'do both things',
+      tools: [
+        autoTool,
+        manualTool,
+      ] as const,
+    });
+
+    const response = await result.getResponse();
+
+    // The response with the unresolved manual call is surfaced so the caller
+    // can execute it and continue the conversation.
+    expect(response.id).toBe('resp_mixed');
+    // No follow-up request was made: its input would have contained
+    // exec_command's function_call with no matching function_call_output,
+    // which providers reject with a 400 ("No tool output found for function
+    // call ...").
+    expect(mockBetaResponsesSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('still loops when every tool call in the round resolves', async () => {
+    const autoOnlyResponse = makeResponse('resp_auto', [
+      functionCallItem('call_auto_1', 'auto_search', '{"query":"docs"}'),
+    ]);
+
+    mockBetaResponsesSend
+      .mockResolvedValueOnce({
+        ok: true,
+        value: autoOnlyResponse,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: textResponse('resp_final', 'All done.'),
+      });
+
+    const result = callModel(client, {
+      model: 'test-model',
+      input: 'search the docs',
+      tools: [
+        autoTool,
+        manualTool,
+      ] as const,
+    });
+
+    const text = await result.getText();
+
+    expect(text).toBe('All done.');
+    expect(mockBetaResponsesSend).toHaveBeenCalledTimes(2);
+
+    // The follow-up request pairs the executed call with its real output.
+    const followupInput = mockBetaResponsesSend.mock.calls[1]?.[1]?.responsesRequest
+      ?.input as unknown[];
+    expect(Array.isArray(followupInput)).toBe(true);
+    const fnCallOutput = followupInput.find(
+      (
+        i,
+      ): i is {
+        type: string;
+        callId: string;
+        output: string;
+      } =>
+        typeof i === 'object' &&
+        i !== null &&
+        (
+          i as {
+            type?: string;
+          }
+        ).type === 'function_call_output',
+    );
+    expect(fnCallOutput?.callId).toBe('call_auto_1');
+    expect(fnCallOutput?.output).toContain('found it');
+  });
+});


### PR DESCRIPTION
## Summary

When a tool round mixes auto-executed tools with manual (no `execute` fn) client tools, `executeToolRound` produces no output for the manual calls, but the loop in `ModelResult` still called `makeFollowupRequest` — sending a history containing the manual `function_call` with no matching `function_call_output`, which providers deterministically reject with a 400 "No tool output found for function call ...".

New guard in the main execution loop, right after the HITL-pause check:

```ts
const resolvedCallIds = new Set(toolResults.map((r) => r.callId));
const hasUnresolvedToolCalls = currentToolCalls.some((tc) => !resolvedCallIds.has(tc.id));
if (hasUnresolvedToolCalls) {
  break;
}
```

Break-and-surface (rather than stub outputs à la the `stopWhen` tail) mirrors the existing all-manual `hasExecutableToolCalls` guards: the caller receives the response, executes its manual calls, and continues the conversation. Also covers calls to tool names not present in `options.tools` at all.

Includes a regression test (`mixed-manual-tool-round.test.ts`) that is red on the current loop (poisoned follow-up sent) and green with the guard, plus an all-auto case verifying the loop still continues normally. Changeset: patch bump.

## Production incident this fixes

**Symptom:** Codex Desktop turns on `openai/gpt-5.5` via OpenRouter `/api/v1/responses` died mid-turn with the generic error **"Server tool request failed"** — 9 failed turns across Jul 7–8, each needing a manual "continue" to resume. Failures always landed seconds after web-search activity in long, multi-tool turns.

### E2E flow that triggers the bug

1. Codex sends `web_search` + `image_generation` (OpenRouter server tools) **plus** its own client function tools (`exec_command`, ...). `image_generation` isn't native-eligible, so the router takes `server-tools:native-fallback-to-sdk` → SDK interception via `@openrouter/agent`'s `callModel` loop.
2. In that loop, Codex's client tools are registered without `execute` ("manual") — the SDK cannot run them.
3. The inner model emits **a `web_search` call and an `exec_command` call in the same round**. `executeToolRound` executes `web_search` but returns nothing for `exec_command` (not HITL → not in `pausedCalls` either).
4. The loop then unconditionally called `makeFollowupRequest`, whose input is `[...history, ...model output, ...toolResults]` — carrying `exec_command`'s `function_call` with **no matching `function_call_output`**.
5. OpenAI returns `400 invalid_request_error, param: "input" — "No tool output found for function call call_XXX."` The Azure failover returns the identical 400 (deterministic, so retries can't help).
6. The consumer's event mapping masks non-auth upstream errors, so the client only ever sees `Server tool request failed` via `response.failed`.

With the guard, step 4 never happens: the loop breaks and surfaces the response, the client executes `exec_command` itself and sends the output back, and the conversation continues — the same contract the loop already honors when *all* calls in a round are manual.

### Failing generation IDs (all 9, same nested-400 signature)

| # | Failure time (PT) | Parent generation ID |
|---|---|---|
| 1 | Jul 7 12:14:19 | `gen-1783440842-oCj0vbNDTO82qAeFaQUA` |
| 2 | Jul 7 12:14:35 | `gen-1783440863-kiiI3dwzhddJ7enZtlkx` |
| 3 | Jul 7 17:51:36 | `gen-1783461081-ET5BsGwoQavwKO33pNTA` |
| 4 | Jul 7 17:53:45 | `gen-1783461211-IJNonTceUZYItOSyhBLn` |
| 5 | Jul 7 17:55:02 | `gen-1783461289-WR6Ep2xF8So0Rwu77YFf` |
| 6 | Jul 7 18:15:20 | `gen-1783462506-ul0WMJ1OoWBB33XotnuT` → nested `gen-1783462519-SyRqzI4Kl8OXr9OySeYp`, missing output for `call_icUiQZXCN0xpcRIW4UEDB9hM` |
| 7 | Jul 7 18:41:24 | `gen-1783464070-Ja08WSZX0sBCRwkG0UjR` |
| 8 | Jul 8 09:25:55 | `gen-1783517129-njmEZGWFW2nwn0EFJKpd` |
| 9 | Jul 8 09:28:56 | `gen-1783517312-DuEXxgR9A0Lh6JTYzBCs` |

Ruled out as causes: Codex's `/models` decode error (`missing field 'models'`) and a dead local `qmd` MCP server — both present in logs but uncorrelated with the failures.

Datadog signal to watch post-deploy: `server-tools:upstream-error` with `raw_message: "No tool output found for function call ..."` should drop to zero.

Link to Devin session: https://openrouter.devinenterprise.com/sessions/8f73f70aa85546efaf30d8c21472357f
Requested by: @ayush-or