### PR TITLE
fix(agent): normalize string input when resuming with loaded history

### DIFF
--- a/.changeset/fix-resume-string-input.md
+++ b/.changeset/fix-resume-string-input.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/agent": patch
+---
+
+Fix: bare string `input` is now normalized into a message item when resuming a conversation with loaded history. Previously the raw string was appended to the request input array un-normalized, causing an OpenResponses 400 validation error on the advertised string-input style.

--- a/packages/agent/src/lib/model-result.ts
+++ b/packages/agent/src/lib/model-result.ts
@@ -1556,15 +1556,13 @@ export class ModelResult<
         // SDK input items with different nominal types, and BaseInputsUnion
         // already includes `any` in its element type, so the runtime shape
         // is preserved either way.
+        // Normalize (not just wrap): bare strings must become EasyInputMessage
+        // items, exactly as the no-history branch does via
+        // normalizeInputToArray. Passing a raw string through to the request
+        // input array is rejected by OpenResponses validation (400).
         const newInput = baseRequest.input;
-        let freshItems: models.BaseInputsUnion[] | undefined;
-        if (newInput !== undefined) {
-          freshItems = Array.isArray(newInput)
-            ? (newInput as models.BaseInputsUnion[])
-            : [
-                newInput,
-              ];
-        }
+        const freshItems: models.BaseInputsUnion[] | undefined =
+          newInput !== undefined ? normalizeInputToArray(newInput) : undefined;
 
         // Hook fresh items only (historical function_calls serve as
         // name-resolution context). Leave historical items untouched.

--- a/packages/agent/tests/unit/resume-string-input.test.ts
+++ b/packages/agent/tests/unit/resume-string-input.test.ts
@@ -1,0 +1,156 @@
+import type { OpenRouterCore } from '@openrouter/sdk/core';
+import type * as models from '@openrouter/sdk/models';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ConversationState, StateAccessor } from '../../src/index.js';
+import { callModel } from '../../src/inner-loop/call-model.js';
+
+const mockBetaResponsesSend = vi.hoisted(() => vi.fn());
+
+vi.mock('@openrouter/sdk/funcs/betaResponsesSend', () => ({
+  betaResponsesSend: mockBetaResponsesSend,
+}));
+
+function textResponse(text: string): models.OpenResponsesResult {
+  return {
+    id: 'resp_text',
+    object: 'response',
+    createdAt: 0,
+    model: 'test-model',
+    status: 'completed',
+    completedAt: 0,
+    output: [
+      {
+        id: 'msg_1',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [
+          {
+            type: 'output_text',
+            text,
+            annotations: [],
+          },
+        ],
+      },
+    ],
+    error: null,
+    incompleteDetails: null,
+    temperature: null,
+    topP: null,
+    presencePenalty: null,
+    frequencyPenalty: null,
+    metadata: null,
+    instructions: null,
+    tools: [],
+    toolChoice: 'auto',
+    parallelToolCalls: false,
+  } as models.OpenResponsesResult;
+}
+
+const client = {} as OpenRouterCore;
+
+describe('Resume with string input (history + fresh string)', () => {
+  let storedState: ConversationState | null;
+  let stateAccessor: StateAccessor;
+
+  beforeEach(() => {
+    mockBetaResponsesSend.mockReset();
+    storedState = null;
+    stateAccessor = {
+      load: async () => storedState,
+      save: async (state) => {
+        storedState = state;
+      },
+    };
+  });
+
+  it('normalizes a bare string input into a message item when resuming loaded history', async () => {
+    // Turn 1: establish history in state.
+    mockBetaResponsesSend.mockResolvedValueOnce({
+      ok: true,
+      value: textResponse('First answer.'),
+    });
+
+    const result1 = callModel(client, {
+      model: 'test-model',
+      input: 'First question',
+      state: stateAccessor,
+    });
+    await result1.getText();
+
+    expect(storedState).not.toBeNull();
+    expect((storedState!.messages as unknown[]).length).toBeGreaterThan(0);
+
+    // Turn 2: resume the same state with a BARE STRING input. Before the fix,
+    // the raw string was appended to the request input array un-normalized,
+    // producing an invalid request (OpenResponses 400).
+    mockBetaResponsesSend.mockResolvedValueOnce({
+      ok: true,
+      value: textResponse('Second answer.'),
+    });
+
+    const result2 = callModel(client, {
+      model: 'test-model',
+      input: 'Follow-up question',
+      state: stateAccessor,
+    });
+    await result2.getText();
+
+    // Inspect the actual request sent on turn 2.
+    const request = mockBetaResponsesSend.mock.calls[1]?.[1]?.responsesRequest as {
+      input: unknown;
+    };
+    expect(Array.isArray(request.input)).toBe(true);
+    const inputItems = request.input as unknown[];
+
+    // No raw strings anywhere in the request input array.
+    for (const item of inputItems) {
+      expect(typeof item).not.toBe('string');
+    }
+
+    // The final item is the normalized fresh user message.
+    const last = inputItems[inputItems.length - 1] as {
+      role?: string;
+      content?: string;
+    };
+    expect(last.role).toBe('user');
+    expect(last.content).toBe('Follow-up question');
+  });
+
+  it('still accepts array input when resuming loaded history', async () => {
+    mockBetaResponsesSend.mockResolvedValueOnce({
+      ok: true,
+      value: textResponse('First answer.'),
+    });
+    await callModel(client, {
+      model: 'test-model',
+      input: 'First question',
+      state: stateAccessor,
+    }).getText();
+
+    mockBetaResponsesSend.mockResolvedValueOnce({
+      ok: true,
+      value: textResponse('Second answer.'),
+    });
+    await callModel(client, {
+      model: 'test-model',
+      input: [
+        {
+          role: 'user',
+          content: 'Follow-up question',
+        },
+      ],
+      state: stateAccessor,
+    }).getText();
+
+    const request = mockBetaResponsesSend.mock.calls[1]?.[1]?.responsesRequest as {
+      input: unknown[];
+    };
+    const last = request.input[request.input.length - 1] as {
+      role?: string;
+      content?: string;
+    };
+    expect(last.role).toBe('user');
+    expect(last.content).toBe('Follow-up question');
+  });
+});


### PR DESCRIPTION
## Problem
Resuming a `ConversationState` with a bare-string `input` (the README's recommended style) appends the raw string to the request input array → OpenResponses 400 `SDKValidationError`. Found battletesting a serverless agent's cold-start resume (OpenRouterTeam/agent-monorepo, wikillm FRICTION #2).

## Root cause
`ModelResult.initStream`: the no-history branch normalizes via `normalizeInputToArray`; the history+fresh branch only wrapped: `[newInput]`.

## Fix
Use `normalizeInputToArray` in the history+fresh branch (helper already imported).

## Tests
`tests/unit/resume-string-input.test.ts` — fails without the fix. Suite: 299 green. Changeset: patch.
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->