### PR TITLE
docs(agent): fix README/API drift — ctx.local, StateAccessor, stream semantics

### DIFF
--- a/.changeset/docs-readme-api-drift.md
+++ b/.changeset/docs-readme-api-drift.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/agent": patch
+---
+
+Docs: fix three README/API drifts found while building production agents — tool context is `ctx.local` (not `ctx.context`); the `state` option takes a `StateAccessor` (`{load, save}`) and state is read via `result.getState()` (not `(await getResponse()).state`); `getToolStream()` emits argument deltas + generator preliminary results, while execution results are on `getFullResponsesStream()`. Adds a streams cheat-sheet table.

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -82,9 +82,14 @@ for await (const delta of result.getReasoningStream()) {
   process.stdout.write(delta);
 }
 
-// Stream tool execution events
+// Stream tool-call argument deltas (plus preliminary results from generator tools)
 for await (const event of result.getToolStream()) {
-  console.log(event);
+  console.log(event); // { type: 'delta', content: '...' } | { type: 'preliminary_result', ... }
+}
+
+// Stream all response events, including tool execution results
+for await (const event of result.getFullResponsesStream()) {
+  // includes tool.result / tool.call_output events
 }
 
 // Stream structured tool calls
@@ -95,6 +100,17 @@ for await (const toolCall of result.getToolCallsStream()) {
 // Get all tool calls after completion
 const toolCalls = await result.getToolCalls();
 ```
+
+What each stream emits:
+
+| Method | Emits |
+|---|---|
+| `getTextStream()` | assistant text deltas |
+| `getReasoningStream()` | reasoning deltas |
+| `getToolStream()` | tool-call **argument deltas**; `preliminary_result` events for generator tools — *not* execution results |
+| `getToolCallsStream()` | parsed tool calls as they complete |
+| `getItemsStream()` | all output items (messages, function calls, …) |
+| `getFullResponsesStream()` | every response event, including `tool.result` / `tool.call_output` execution events |
 
 ### Tool Types
 
@@ -234,7 +250,8 @@ const dbTool = tool({
   inputSchema: z.object({ sql: z.string() }),
   contextSchema: z.object({ connectionString: z.string() }),
   execute: async ({ sql }, ctx) => {
-    const db = connect(ctx?.context.connectionString);
+    // Tool context is available on ctx.local
+    const db = connect(ctx?.local.connectionString);
     return db.query(sql);
   },
 });
@@ -267,13 +284,22 @@ const result = callModel(client, {
 
 ### Conversation State Management
 
-Persist multi-turn conversations with full state tracking:
+Persist multi-turn conversations with full state tracking. The `state`
+option takes a `StateAccessor` — a `{ load, save }` pair over any storage
+backend (memory, SQLite, Redis, …). The loop calls `load` before the run and
+`save` as the conversation progresses:
 
 ```typescript
-import { createInitialState, callModel } from '@openrouter/agent';
+import { callModel, type ConversationState, type StateAccessor } from '@openrouter/agent';
 
-// Start a conversation
-let state = createInitialState();
+// Any storage backend — here, a simple in-memory holder
+let stored: ConversationState | null = null;
+const state: StateAccessor = {
+  load: async () => stored,
+  save: async (s) => {
+    stored = s;
+  },
+};
 
 // First turn
 const result1 = callModel(client, {
@@ -282,11 +308,12 @@ const result1 = callModel(client, {
   tools: [searchTool] as const,
   state,
 });
+await result1.getText();
 
-// State is updated with messages, tool calls, and metadata
-state = (await result1.getResponse()).state;
+// Read the updated state (messages, tool calls, status, metadata)
+const snapshot = await result1.getState();
 
-// Continue the conversation
+// Continue the conversation — the accessor loads the saved history
 const result2 = callModel(client, {
   model: 'openai/gpt-4o',
   input: 'Now summarize what you found',
@@ -294,6 +321,9 @@ const result2 = callModel(client, {
   state,
 });
 ```
+
+`ConversationState` is plain JSON — `JSON.stringify`/`JSON.parse` it into any
+store (this is how serverless/cold-start resume works).
 
 ### Dynamic Parameters Between Turns
 


### PR DESCRIPTION
Three README sections document APIs that don't exist (each cost real debugging time building production agents on the SDK):

1. **Tool Context**: `ctx?.context.…` → actual API is `ctx.local`
2. **Conversation State**: `state` as mutable value + `(await getResponse()).state` → actual API is a `StateAccessor` (`{load, save}`), read via `result.getState()`
3. **Streams**: `getToolStream()` yields argument deltas (+ generator `preliminary_result`), not execution events — those are on `getFullResponsesStream()`

Corrected against source; added a streams cheat-sheet table; StateAccessor example notes plain-JSON serverless resume. Docs-only. Related: SDK-423/SDK-307.
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->