### PR TITLE
fix(agent): infer tool context types from contextSchema

### DIFF
--- a/.changeset/fix-context-schema-inference.md
+++ b/.changeset/fix-context-schema-inference.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/agent": patch
+---
+
+Infer tool context types from `contextSchema` end-to-end: `tool()` now preserves the concrete Zod schema through its overloads, so `execute`'s `ctx.local` is typed from the schema and `callModel`'s `context` map slots accept/reject the real per-tool shape — no more `ctx.local as X` or `context: map as any`. Tools without a `contextSchema` still resolve their map slot to `Record<string, never>`. Types-only; runtime behavior unchanged.

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -112,7 +112,7 @@
     "test": "vitest --run --project unit",
     "test:e2e": "vitest --run --project e2e",
     "test:watch": "vitest --watch --project unit",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "compile": "tsc"
   },
   "dependencies": {

--- a/packages/agent/src/lib/tool-types.ts
+++ b/packages/agent/src/lib/tool-types.ts
@@ -64,16 +64,6 @@ export type ContextFromSchema<TCtx extends $ZodObject<$ZodShape>> =
       : zodInfer<TCtx> & Record<string, unknown>;
 
 /**
- * @deprecated no longer used — the concrete schema type is carried directly
- * on `BaseToolFunction.contextSchema` (readonly ⇒ covariant TCtx), and
- * `InferToolContext` distinguishes the wide default from concrete schemas.
- * Kept as an alias for source compatibility.
- */
-export type WithConcreteContextSchema<_TCtx extends $ZodObject<$ZodShape>> =
-  // biome-ignore lint/complexity/noBannedTypes: intentional empty type
-  {};
-
-/**
  * Extract tool name from a tool definition
  */
 type InferToolName<T> = T extends {
@@ -385,8 +375,7 @@ export type ToolWithExecute<
   TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
 > = {
   type: ToolType.Function;
-  function: ToolFunctionWithExecute<TInput, TOutput, TContext, string, TCtx> &
-    WithConcreteContextSchema<TCtx>;
+  function: ToolFunctionWithExecute<TInput, TOutput, TContext, string, TCtx>;
 };
 
 /**
@@ -401,8 +390,7 @@ export type ToolWithGenerator<
   TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
 > = {
   type: ToolType.Function;
-  function: ToolFunctionWithGenerator<TInput, TEvent, TOutput, TContext, string, TCtx> &
-    WithConcreteContextSchema<TCtx>;
+  function: ToolFunctionWithGenerator<TInput, TEvent, TOutput, TContext, string, TCtx>;
 };
 
 /**
@@ -415,7 +403,7 @@ export type ManualTool<
   TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
 > = {
   type: ToolType.Function;
-  function: ManualToolFunction<TInput, TOutput, TCtx> & WithConcreteContextSchema<TCtx>;
+  function: ManualToolFunction<TInput, TOutput, TCtx>;
 };
 
 /**
@@ -429,8 +417,7 @@ export type HITLTool<
   TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
 > = {
   type: ToolType.Function;
-  function: HITLToolFunction<TInput, TOutput, TContext, string, TCtx> &
-    WithConcreteContextSchema<TCtx>;
+  function: HITLToolFunction<TInput, TOutput, TContext, string, TCtx>;
 };
 
 /**

--- a/packages/agent/src/lib/tool-types.ts
+++ b/packages/agent/src/lib/tool-types.ts
@@ -25,18 +25,53 @@ export interface TurnContext {
 //#region Context Types
 
 /**
- * Extract context schema type from a tool definition
- * Returns the inferred type of the tool's contextSchema, or empty object if none
+ * Extract context schema type from a tool definition.
+ * Returns the inferred type of the tool's `contextSchema`, or
+ * `Record<string, never>` when the tool has no (required) contextSchema.
+ *
+ * Note: optional `contextSchema?: ...` does not match; tools produced by
+ * `tool()` only mark `contextSchema` as required when one was provided, so
+ * tools without a schema keep `Record<string, never>` map slots.
  */
 export type InferToolContext<T> = T extends {
   function: {
-    contextSchema: infer S;
+    readonly contextSchema?: infer S;
   };
 }
-  ? S extends $ZodType
-    ? zodInfer<S>
+  ? [
+      S,
+    ] extends [
+      $ZodObject<$ZodShape>,
+    ]
+    ? $ZodObject<$ZodShape> extends S
+      ? Record<string, never> // wide/default schema type ⇒ tool declared no context
+      : zodInfer<S> extends Record<string, unknown>
+        ? zodInfer<S>
+        : zodInfer<S> & Record<string, unknown>
     : Record<string, never>
   : Record<string, never>;
+
+/**
+ * Resolve execute-context shape from a contextSchema generic.
+ * - Wide/default `$ZodObject<$ZodShape>` (no schema provided) → `Record<string, unknown>`
+ * - Concrete schema → its Zod-inferred shape
+ */
+export type ContextFromSchema<TCtx extends $ZodObject<$ZodShape>> =
+  $ZodObject<$ZodShape> extends TCtx
+    ? Record<string, unknown>
+    : zodInfer<TCtx> extends Record<string, unknown>
+      ? zodInfer<TCtx>
+      : zodInfer<TCtx> & Record<string, unknown>;
+
+/**
+ * @deprecated no longer used — the concrete schema type is carried directly
+ * on `BaseToolFunction.contextSchema` (readonly ⇒ covariant TCtx), and
+ * `InferToolContext` distinguishes the wide default from concrete schemas.
+ * Kept as an alias for source compatibility.
+ */
+export type WithConcreteContextSchema<_TCtx extends $ZodObject<$ZodShape>> =
+  // biome-ignore lint/complexity/noBannedTypes: intentional empty type
+  {};
 
 /**
  * Extract tool name from a tool definition
@@ -134,10 +169,14 @@ export type NextTurnParamsContext = {
  * Each function receives the tool's input params and current request context
  */
 export type NextTurnParamsFunctions<TInput> = {
-  [K in keyof NextTurnParamsContext]?: (
-    params: TInput,
-    context: NextTurnParamsContext,
-  ) => NextTurnParamsContext[K] | Promise<NextTurnParamsContext[K]>;
+  // Method syntax via mapped object for bivariant `params` — keeps tools
+  // with concrete TInput assignable to the wide `Tool` union (see execute()).
+  [K in keyof NextTurnParamsContext]?: {
+    bivarianceHack(
+      params: TInput,
+      context: NextTurnParamsContext,
+    ): NextTurnParamsContext[K] | Promise<NextTurnParamsContext[K]>;
+  }['bivarianceHack'];
 };
 
 /**
@@ -145,10 +184,10 @@ export type NextTurnParamsFunctions<TInput> = {
  * Receives the tool's input params and turn context
  * Returns true if approval is required, false otherwise
  */
-export type ToolApprovalCheck<TInput> = (
-  params: TInput,
-  context: TurnContext,
-) => boolean | Promise<boolean>;
+export type ToolApprovalCheck<TInput> = {
+  // Bivariant params — see NextTurnParamsFunctions.
+  bivarianceHack(params: TInput, context: TurnContext): boolean | Promise<boolean>;
+}['bivarianceHack'];
 
 /**
  * Content item types for tool output to model.
@@ -185,21 +224,34 @@ export type ToModelOutputResult = {
  * @template TInput - The tool's input type
  * @template TOutput - The tool's output type
  */
-export type ToModelOutputFunction<TInput, TOutput> = (params: {
-  output: TOutput;
-  input: TInput;
-}) => ToModelOutputResult | Promise<ToModelOutputResult>;
+// Object-with-method form (not a bare function type) so the params position
+// is checked bivariantly — concrete TInput/TOutput tools stay assignable to
+// the wide `Tool` union. See the execute() members for the same pattern.
+export type ToModelOutputFunction<TInput, TOutput> = {
+  bivarianceHack(params: {
+    output: TOutput;
+    input: TInput;
+  }): ToModelOutputResult | Promise<ToModelOutputResult>;
+}['bivarianceHack'];
 
 /**
  * Base tool function interface with inputSchema
  * @template TInput - Zod schema for tool input
+ * @template TCtx - Zod schema for tool context (optional; default = erased wide type)
  */
-export interface BaseToolFunction<TInput extends $ZodObject<$ZodShape>> {
+export interface BaseToolFunction<
+  TInput extends $ZodObject<$ZodShape>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
+> {
   name: string;
   description?: string;
   inputSchema: TInput;
-  /** Zod schema declaring the context data this tool needs */
-  contextSchema?: $ZodObject<$ZodShape>;
+  /**
+   * Zod schema declaring the context data this tool needs.
+   * `readonly` keeps TCtx covariant so tools carrying a concrete schema stay
+   * assignable to the wide `Tool` union.
+   */
+  readonly contextSchema?: TCtx;
   nextTurnParams?: NextTurnParamsFunctions<zodInfer<TInput>>;
   /**
    * Whether this tool requires human approval before execution
@@ -218,12 +270,16 @@ export interface ToolFunctionWithExecute<
   TOutput extends $ZodType = $ZodType<unknown>,
   TContext extends Record<string, unknown> = Record<string, unknown>,
   TName extends string = string,
-> extends BaseToolFunction<TInput> {
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
+> extends BaseToolFunction<TInput, TCtx> {
   outputSchema?: TOutput;
-  execute: (
+  // Method syntax (not property syntax) is deliberate: methods are checked
+  // bivariantly, so tools carrying concrete TInput/TContext types remain
+  // assignable to the wide `Tool` union despite contravariant params.
+  execute(
     params: zodInfer<TInput>,
     context?: ToolExecuteContext<TName, TContext>,
-  ) => Promise<zodInfer<TOutput>> | zodInfer<TOutput>;
+  ): Promise<zodInfer<TOutput>> | zodInfer<TOutput>;
   /** Convert tool execution output to model-facing output */
   toModelOutput?: ToModelOutputFunction<zodInfer<TInput>, zodInfer<TOutput>>;
 }
@@ -256,13 +312,15 @@ export interface ToolFunctionWithGenerator<
   TOutput extends $ZodType = $ZodType<unknown>,
   TContext extends Record<string, unknown> = Record<string, unknown>,
   TName extends string = string,
-> extends BaseToolFunction<TInput> {
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
+> extends BaseToolFunction<TInput, TCtx> {
   eventSchema: TEvent;
   outputSchema: TOutput;
-  execute: (
+  // Method syntax for bivariant param checking — see ToolFunctionWithExecute.
+  execute(
     params: zodInfer<TInput>,
     context?: ToolExecuteContext<TName, TContext>,
-  ) => AsyncGenerator<zodInfer<TEvent> | zodInfer<TOutput>, zodInfer<TOutput> | undefined>;
+  ): AsyncGenerator<zodInfer<TEvent> | zodInfer<TOutput>, zodInfer<TOutput> | undefined>;
   /** Convert tool execution output to model-facing output */
   toModelOutput?: ToModelOutputFunction<zodInfer<TInput>, zodInfer<TOutput>>;
 }
@@ -273,7 +331,8 @@ export interface ToolFunctionWithGenerator<
 export interface ManualToolFunction<
   TInput extends $ZodObject<$ZodShape>,
   TOutput extends $ZodType = $ZodType<unknown>,
-> extends BaseToolFunction<TInput> {
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
+> extends BaseToolFunction<TInput, TCtx> {
   outputSchema?: TOutput;
 }
 
@@ -294,7 +353,8 @@ export interface HITLToolFunction<
   TOutput extends $ZodType = $ZodType<unknown>,
   TContext extends Record<string, unknown> = Record<string, unknown>,
   TName extends string = string,
-> extends BaseToolFunction<TInput> {
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
+> extends BaseToolFunction<TInput, TCtx> {
   /**
    * Required for HITL tools. Used to validate both the `onToolCalled` return
    * value (when non-null) and the caller-supplied response that comes back via
@@ -302,63 +362,75 @@ export interface HITLToolFunction<
    * `onResponseReceived` or passed through directly when no hook is defined.
    */
   outputSchema: TOutput;
-  onToolCalled: (
+  // Method syntax for bivariant param checking — see ToolFunctionWithExecute.
+  onToolCalled(
     params: zodInfer<TInput>,
     context?: ToolExecuteContext<TName, TContext>,
-  ) => Promise<zodInfer<TOutput> | null> | zodInfer<TOutput> | null;
-  onResponseReceived?: (
+  ): Promise<zodInfer<TOutput> | null> | zodInfer<TOutput> | null;
+  onResponseReceived?(
     rawResult: unknown,
     context?: ToolExecuteContext<TName, TContext>,
-  ) => Promise<zodInfer<TOutput>> | zodInfer<TOutput>;
+  ): Promise<zodInfer<TOutput>> | zodInfer<TOutput>;
   toModelOutput?: ToModelOutputFunction<zodInfer<TInput>, zodInfer<TOutput>>;
 }
 
 /**
  * Tool with execute function (regular or generator)
+ * @template TCtx - The concrete contextSchema type when one was provided to `tool()`
  */
 export type ToolWithExecute<
   TInput extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
   TOutput extends $ZodType = $ZodType<unknown>,
   TContext extends Record<string, unknown> = Record<string, unknown>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
 > = {
   type: ToolType.Function;
-  function: ToolFunctionWithExecute<TInput, TOutput, TContext>;
+  function: ToolFunctionWithExecute<TInput, TOutput, TContext, string, TCtx> &
+    WithConcreteContextSchema<TCtx>;
 };
 
 /**
  * Tool with generator execute function
+ * @template TCtx - The concrete contextSchema type when one was provided to `tool()`
  */
 export type ToolWithGenerator<
   TInput extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
   TEvent extends $ZodType = $ZodType<unknown>,
   TOutput extends $ZodType = $ZodType<unknown>,
   TContext extends Record<string, unknown> = Record<string, unknown>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
 > = {
   type: ToolType.Function;
-  function: ToolFunctionWithGenerator<TInput, TEvent, TOutput, TContext>;
+  function: ToolFunctionWithGenerator<TInput, TEvent, TOutput, TContext, string, TCtx> &
+    WithConcreteContextSchema<TCtx>;
 };
 
 /**
  * Tool without execute function (manual handling)
+ * @template TCtx - The concrete contextSchema type when one was provided to `tool()`
  */
 export type ManualTool<
   TInput extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
   TOutput extends $ZodType = $ZodType<unknown>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
 > = {
   type: ToolType.Function;
-  function: ManualToolFunction<TInput, TOutput>;
+  function: ManualToolFunction<TInput, TOutput, TCtx> & WithConcreteContextSchema<TCtx>;
 };
 
 /**
  * Human-in-the-loop tool (with onToolCalled / onResponseReceived hooks)
+ * @template TCtx - The concrete contextSchema type when one was provided to `tool()`
  */
 export type HITLTool<
   TInput extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
   TOutput extends $ZodType = $ZodType<unknown>,
   TContext extends Record<string, unknown> = Record<string, unknown>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
 > = {
   type: ToolType.Function;
-  function: HITLToolFunction<TInput, TOutput, TContext>;
+  function: HITLToolFunction<TInput, TOutput, TContext, string, TCtx> &
+    WithConcreteContextSchema<TCtx>;
 };
 
 /**

--- a/packages/agent/src/lib/tool.ts
+++ b/packages/agent/src/lib/tool.ts
@@ -1,5 +1,6 @@
 import type { $ZodObject, $ZodShape, $ZodType, infer as zodInfer } from 'zod/v4/core';
 import type {
+  ContextFromSchema,
   HITLTool,
   ManualTool,
   McpBranded,
@@ -19,12 +20,14 @@ import { SHARED_CONTEXT_KEY, ToolType } from './tool-types.js';
 //#region Config Types
 
 /**
- * Configuration for a regular tool with outputSchema
+ * Configuration for a regular tool with outputSchema.
+ * `TCtx` preserves a concrete `contextSchema` through the overload boundary so
+ * execute's `ctx.local` and the returned tool's `function.contextSchema` stay typed.
  */
 type RegularToolConfigWithOutput<
   TInput extends $ZodObject<$ZodShape>,
   TOutput extends $ZodType,
-  TContext extends Record<string, unknown> = Record<string, unknown>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
   TName extends string = string,
 > = {
   name: TName;
@@ -33,12 +36,12 @@ type RegularToolConfigWithOutput<
   outputSchema: TOutput;
   eventSchema?: undefined;
   /** Zod schema declaring the context data this tool needs */
-  contextSchema?: $ZodObject<$ZodShape>;
+  contextSchema?: TCtx;
   nextTurnParams?: NextTurnParamsFunctions<zodInfer<TInput>>;
   requireApproval?: boolean | ToolApprovalCheck<zodInfer<TInput>>;
   execute: (
     params: zodInfer<TInput>,
-    context?: ToolExecuteContext<TName, TContext>,
+    context?: ToolExecuteContext<TName, ContextFromSchema<TCtx>>,
   ) => Promise<zodInfer<TOutput>> | zodInfer<TOutput>;
   /** Convert tool execution output to model-facing output */
   toModelOutput?: ToModelOutputFunction<zodInfer<TInput>, zodInfer<TOutput>>;
@@ -50,7 +53,7 @@ type RegularToolConfigWithOutput<
 type RegularToolConfigWithoutOutput<
   TInput extends $ZodObject<$ZodShape>,
   TReturn,
-  TContext extends Record<string, unknown> = Record<string, unknown>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
   TName extends string = string,
 > = {
   name: TName;
@@ -59,12 +62,12 @@ type RegularToolConfigWithoutOutput<
   outputSchema?: undefined;
   eventSchema?: undefined;
   /** Zod schema declaring the context data this tool needs */
-  contextSchema?: $ZodObject<$ZodShape>;
+  contextSchema?: TCtx;
   nextTurnParams?: NextTurnParamsFunctions<zodInfer<TInput>>;
   requireApproval?: boolean | ToolApprovalCheck<zodInfer<TInput>>;
   execute: (
     params: zodInfer<TInput>,
-    context?: ToolExecuteContext<TName, TContext>,
+    context?: ToolExecuteContext<TName, ContextFromSchema<TCtx>>,
   ) => Promise<TReturn> | TReturn;
   /** Convert tool execution output to model-facing output */
   toModelOutput?: ToModelOutputFunction<zodInfer<TInput>, TReturn>;
@@ -77,7 +80,7 @@ type GeneratorToolConfig<
   TInput extends $ZodObject<$ZodShape>,
   TEvent extends $ZodType,
   TOutput extends $ZodType,
-  TContext extends Record<string, unknown> = Record<string, unknown>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
   TName extends string = string,
 > = {
   name: TName;
@@ -86,12 +89,12 @@ type GeneratorToolConfig<
   eventSchema: TEvent;
   outputSchema: TOutput;
   /** Zod schema declaring the context data this tool needs */
-  contextSchema?: $ZodObject<$ZodShape>;
+  contextSchema?: TCtx;
   nextTurnParams?: NextTurnParamsFunctions<zodInfer<TInput>>;
   requireApproval?: boolean | ToolApprovalCheck<zodInfer<TInput>>;
   execute: (
     params: zodInfer<TInput>,
-    context?: ToolExecuteContext<TName, TContext>,
+    context?: ToolExecuteContext<TName, ContextFromSchema<TCtx>>,
   ) => AsyncGenerator<zodInfer<TEvent> | zodInfer<TOutput>>;
   /** Convert tool execution output to model-facing output */
   toModelOutput?: ToModelOutputFunction<zodInfer<TInput>, zodInfer<TOutput>>;
@@ -100,12 +103,15 @@ type GeneratorToolConfig<
 /**
  * Configuration for a manual tool (execute: false, no eventSchema or outputSchema)
  */
-type ManualToolConfig<TInput extends $ZodObject<$ZodShape>> = {
+type ManualToolConfig<
+  TInput extends $ZodObject<$ZodShape>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
+> = {
   name: string; // Manual tools don't use TName since they have no execute
   description?: string;
   inputSchema: TInput;
   /** Zod schema declaring the context data this tool needs */
-  contextSchema?: $ZodObject<$ZodShape>;
+  contextSchema?: TCtx;
   nextTurnParams?: NextTurnParamsFunctions<zodInfer<TInput>>;
   requireApproval?: boolean | ToolApprovalCheck<zodInfer<TInput>>;
   execute: false;
@@ -125,7 +131,7 @@ type ManualToolConfig<TInput extends $ZodObject<$ZodShape>> = {
 type HITLToolConfig<
   TInput extends $ZodObject<$ZodShape>,
   TOutput extends $ZodType,
-  TContext extends Record<string, unknown> = Record<string, unknown>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
   TName extends string = string,
 > = {
   name: TName;
@@ -141,16 +147,16 @@ type HITLToolConfig<
   eventSchema?: undefined;
   execute?: undefined;
   /** Zod schema declaring the context data this tool needs */
-  contextSchema?: $ZodObject<$ZodShape>;
+  contextSchema?: TCtx;
   nextTurnParams?: NextTurnParamsFunctions<zodInfer<TInput>>;
   requireApproval?: boolean | ToolApprovalCheck<zodInfer<TInput>>;
   onToolCalled: (
     params: zodInfer<TInput>,
-    context?: ToolExecuteContext<TName, TContext>,
+    context?: ToolExecuteContext<TName, ContextFromSchema<TCtx>>,
   ) => Promise<zodInfer<TOutput> | null> | zodInfer<TOutput> | null;
   onResponseReceived?: (
     rawResult: unknown,
-    context?: ToolExecuteContext<TName, TContext>,
+    context?: ToolExecuteContext<TName, ContextFromSchema<TCtx>>,
   ) => Promise<zodInfer<TOutput>> | zodInfer<TOutput>;
   /** Convert tool execution output to model-facing output */
   toModelOutput?: ToModelOutputFunction<zodInfer<TInput>, zodInfer<TOutput>>;
@@ -160,23 +166,26 @@ type HITLToolConfig<
  * Loose config type for the `tool<TShared>()` overload.
  * Accepts any valid tool config while typing `ctx.shared` from TShared.
  */
-type ToolConfigWithSharedContext<TShared extends Record<string, unknown>> = {
+type ToolConfigWithSharedContext<
+  TShared extends Record<string, unknown>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
+> = {
   name: string;
   description?: string;
   inputSchema: $ZodObject<$ZodShape>;
   outputSchema?: $ZodType;
   eventSchema?: $ZodType;
-  contextSchema?: $ZodObject<$ZodShape>;
+  contextSchema?: TCtx;
   nextTurnParams?: NextTurnParamsFunctions<Record<string, unknown>>;
   requireApproval?: boolean | ToolApprovalCheck<Record<string, unknown>>;
   execute:
     | ((
         params: Record<string, unknown>,
-        context?: ToolExecuteContext<string, Record<string, unknown>, TShared>,
+        context?: ToolExecuteContext<string, ContextFromSchema<TCtx>, TShared>,
       ) => unknown)
     | ((
         params: Record<string, unknown>,
-        context?: ToolExecuteContext<string, Record<string, unknown>, TShared>,
+        context?: ToolExecuteContext<string, ContextFromSchema<TCtx>, TShared>,
       ) => AsyncGenerator<unknown>)
     | false;
   /** Convert tool execution output to model-facing output */
@@ -194,11 +203,11 @@ type RegularToolConfig<
   TInput extends $ZodObject<$ZodShape>,
   TOutput extends $ZodType,
   TReturn,
-  TContext extends Record<string, unknown> = Record<string, unknown>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
   TName extends string = string,
 > =
-  | RegularToolConfigWithOutput<TInput, TOutput, TContext, TName>
-  | RegularToolConfigWithoutOutput<TInput, TReturn, TContext, TName>;
+  | RegularToolConfigWithOutput<TInput, TOutput, TCtx, TName>
+  | RegularToolConfigWithoutOutput<TInput, TReturn, TCtx, TName>;
 
 //#endregion
 
@@ -230,49 +239,56 @@ type RegularToolConfig<
  * });
  * ```
  */
-// Overload for generator tools (when eventSchema is provided)
+// Overload for generator tools (when eventSchema is provided).
+// TContext on the *returned* tool stays the wide default so specific tools remain
+// assignable to `Tool` / `Tool[]` (function-parameter variance). Typed
+// `ctx.local` is provided by the *config* execute signature via ContextFromSchema;
+// the concrete schema is preserved on the return via TCtx + WithConcreteContextSchema.
 export function tool<
   TInput extends $ZodObject<$ZodShape>,
   TEvent extends $ZodType,
   TOutput extends $ZodType,
-  TContext extends Record<string, unknown> = Record<string, unknown>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
   TName extends string = string,
 >(
-  config: GeneratorToolConfig<TInput, TEvent, TOutput, TContext, TName>,
-): ToolWithGenerator<TInput, TEvent, TOutput, TContext>;
+  config: GeneratorToolConfig<TInput, TEvent, TOutput, TCtx, TName>,
+): ToolWithGenerator<TInput, TEvent, TOutput, Record<string, unknown>, TCtx>;
 
 // Overload for HITL tools (when onToolCalled is provided)
 export function tool<
   TInput extends $ZodObject<$ZodShape>,
   TOutput extends $ZodType,
-  TContext extends Record<string, unknown> = Record<string, unknown>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
   TName extends string = string,
->(config: HITLToolConfig<TInput, TOutput, TContext, TName>): HITLTool<TInput, TOutput, TContext>;
+>(
+  config: HITLToolConfig<TInput, TOutput, TCtx, TName>,
+): HITLTool<TInput, TOutput, Record<string, unknown>, TCtx>;
 
 // Overload for manual tools (execute: false)
-export function tool<TInput extends $ZodObject<$ZodShape>>(
-  config: ManualToolConfig<TInput>,
-): ManualTool<TInput>;
+export function tool<
+  TInput extends $ZodObject<$ZodShape>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
+>(config: ManualToolConfig<TInput, TCtx>): ManualTool<TInput, $ZodType<unknown>, TCtx>;
 
 // Overload for regular tools with outputSchema
 export function tool<
   TInput extends $ZodObject<$ZodShape>,
   TOutput extends $ZodType,
-  TContext extends Record<string, unknown> = Record<string, unknown>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
   TName extends string = string,
 >(
-  config: RegularToolConfigWithOutput<TInput, TOutput, TContext, TName>,
-): ToolWithExecute<TInput, TOutput, TContext>;
+  config: RegularToolConfigWithOutput<TInput, TOutput, TCtx, TName>,
+): ToolWithExecute<TInput, TOutput, Record<string, unknown>, TCtx>;
 
 // Overload for regular tools without outputSchema (infers return type)
 export function tool<
   TInput extends $ZodObject<$ZodShape>,
   TReturn,
-  TContext extends Record<string, unknown> = Record<string, unknown>,
+  TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
   TName extends string = string,
 >(
-  config: RegularToolConfigWithoutOutput<TInput, TReturn, TContext, TName>,
-): ToolWithExecute<TInput, $ZodType<TReturn>, TContext>;
+  config: RegularToolConfigWithoutOutput<TInput, TReturn, TCtx, TName>,
+): ToolWithExecute<TInput, $ZodType<TReturn>, Record<string, unknown>, TCtx>;
 
 // Overload for explicit TShared: tool<SharedContext>({...})
 // When a non-ZodObject type is provided as the first generic,
@@ -321,7 +337,13 @@ export function tool(
     }
 
     if (config.contextSchema !== undefined) {
-      fn.contextSchema = config.contextSchema;
+      // contextSchema is readonly on the type (covariance); assignment at
+      // construction time is the one sanctioned write.
+      (
+        fn as {
+          contextSchema?: unknown;
+        }
+      ).contextSchema = config.contextSchema;
     }
 
     if (config.nextTurnParams !== undefined) {
@@ -358,7 +380,13 @@ export function tool(
     }
 
     if (config.contextSchema !== undefined) {
-      fn.contextSchema = config.contextSchema;
+      // contextSchema is readonly on the type (covariance); assignment at
+      // construction time is the one sanctioned write.
+      (
+        fn as {
+          contextSchema?: unknown;
+        }
+      ).contextSchema = config.contextSchema;
     }
 
     if (config.nextTurnParams !== undefined) {
@@ -390,7 +418,13 @@ export function tool(
     }
 
     if (config.contextSchema !== undefined) {
-      fn.contextSchema = config.contextSchema;
+      // contextSchema is readonly on the type (covariance); assignment at
+      // construction time is the one sanctioned write.
+      (
+        fn as {
+          contextSchema?: unknown;
+        }
+      ).contextSchema = config.contextSchema;
     }
 
     if (config.nextTurnParams !== undefined) {

--- a/packages/agent/src/lib/tool.ts
+++ b/packages/agent/src/lib/tool.ts
@@ -243,7 +243,7 @@ type RegularToolConfig<
 // TContext on the *returned* tool stays the wide default so specific tools remain
 // assignable to `Tool` / `Tool[]` (function-parameter variance). Typed
 // `ctx.local` is provided by the *config* execute signature via ContextFromSchema;
-// the concrete schema is preserved on the return via TCtx + WithConcreteContextSchema.
+// the concrete schema is preserved on the return via TCtx on `BaseToolFunction.contextSchema`.
 export function tool<
   TInput extends $ZodObject<$ZodShape>,
   TEvent extends $ZodType,

--- a/packages/agent/tests/unit/context-schema-inference.test-d.ts
+++ b/packages/agent/tests/unit/context-schema-inference.test-d.ts
@@ -1,0 +1,181 @@
+/**
+ * Type-level tests for contextSchema → TContext / ToolContextMap inference (PR-3).
+ *
+ * Pins the exact consumer shape that previously required `as any`
+ * (see agents/pr-review FRICTION.md #2):
+ * - execute's `ctx.local` is inferred from `contextSchema` (no cast)
+ * - `callModel`'s `context` map accepts the correct per-tool shape
+ * - wrong shapes are rejected
+ * - tools without `contextSchema` keep `Record<string, never>` map slots
+ * - concrete tools remain assignable to the wide `Tool` union
+ *
+ * Assertions are assignability-based (the actual consumer experience)
+ * rather than strict type equality, which is brittle against incidental
+ * modifier differences in the mapped types.
+ */
+
+import { expectTypeOf } from 'vitest';
+import { z } from 'zod';
+import { tool } from '../../src/lib/tool.js';
+import type { Tool, ToolContextMap } from '../../src/lib/tool-types.js';
+
+// --- (a) ctx.local inferred from contextSchema --------------------------------
+
+const readFileTool = tool({
+  name: 'read_file',
+  inputSchema: z.object({
+    path: z.string(),
+  }),
+  contextSchema: z.object({
+    token: z.string(),
+    owner: z.string(),
+  }),
+  execute: async ({ path }, ctx) => {
+    // Acceptance: no cast required — local is typed from contextSchema.
+    const token: string = ctx!.local.token;
+    const owner: string = ctx!.local.owner;
+    expectTypeOf(ctx!.local.token).toEqualTypeOf<string>();
+    expectTypeOf(ctx!.local.owner).toEqualTypeOf<string>();
+    return {
+      ok: true as const,
+      path,
+      token,
+      owner,
+    };
+  },
+});
+
+// --- (b) concrete tools stay assignable to the wide Tool union ----------------
+
+const asWide: Tool = readFileTool;
+const asWideArray: readonly Tool[] = [
+  readFileTool,
+] as const;
+void asWide;
+void asWideArray;
+
+// --- (c) context map accepts the correct shape, rejects wrong ones ------------
+
+type ReadFileMap = ToolContextMap<
+  readonly [
+    typeof readFileTool,
+  ]
+>;
+
+const goodContext: ReadFileMap = {
+  read_file: {
+    token: 'x',
+    owner: 'y',
+  },
+};
+void goodContext;
+
+// wrong shape must be rejected
+declare const wrongShape: {
+  read_file: {
+    wrong: number;
+  };
+};
+// @ts-expect-error 'wrong' is not part of the read_file context shape
+const badContext: ReadFileMap = wrongShape;
+void badContext;
+
+// missing required key must be rejected
+declare const missingKey: {
+  read_file: {
+    token: string;
+  };
+};
+// @ts-expect-error 'owner' is required in the read_file context shape
+const missingKeyContext: ReadFileMap = missingKey;
+void missingKeyContext;
+
+// --- (d) tool without contextSchema keeps Record<string, never> ---------------
+
+const plainTool = tool({
+  name: 'plain',
+  inputSchema: z.object({
+    q: z.string(),
+  }),
+  execute: async ({ q }) => ({
+    q,
+  }),
+});
+
+type PlainMap = ToolContextMap<
+  readonly [
+    typeof plainTool,
+  ]
+>;
+const emptyOk: PlainMap = {
+  plain: {},
+};
+void emptyOk;
+
+declare const plainWithValues: {
+  plain: {
+    anything: number;
+  };
+};
+// @ts-expect-error context values are not allowed for tools without a contextSchema
+const plainRejects: PlainMap = plainWithValues;
+void plainRejects;
+
+// --- (e) mixed array infers per-slot -------------------------------------------
+
+type MixedMap = ToolContextMap<
+  readonly [
+    typeof readFileTool,
+    typeof plainTool,
+  ]
+>;
+
+const mixedGood: MixedMap = {
+  read_file: {
+    token: 'x',
+    owner: 'y',
+  },
+  plain: {},
+};
+void mixedGood;
+
+declare const mixedWrong: {
+  read_file: {
+    token: string;
+    owner: string;
+  };
+  plain: {
+    nope: boolean;
+  };
+};
+// @ts-expect-error per-slot shapes are enforced independently
+const mixedBad: MixedMap = mixedWrong;
+void mixedBad;
+
+// --- (f) manual tools (execute: false) carry context types too ----------------
+
+const manualTool = tool({
+  name: 'approve_thing',
+  inputSchema: z.object({
+    id: z.string(),
+  }),
+  contextSchema: z.object({
+    requester: z.string(),
+  }),
+  execute: false,
+});
+
+const manualAsWide: Tool = manualTool;
+void manualAsWide;
+
+type ManualMap = ToolContextMap<
+  readonly [
+    typeof manualTool,
+  ]
+>;
+const manualGood: ManualMap = {
+  approve_thing: {
+    requester: 'me',
+  },
+};
+void manualGood;

--- a/packages/agent/tsconfig.typecheck.json
+++ b/packages/agent/tsconfig.typecheck.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": true, "rootDir": "." },
+  "include": ["src/**/*.ts", "tests/unit/context-schema-inference.test-d.ts"],
+  "exclude": ["node_modules", "esm"]
+}


### PR DESCRIPTION
## Problem

`contextSchema`'s Zod type never reached `execute`'s context or `callModel`'s `context` map: `ctx` typed as `ToolExecuteContext<Name, Record<string, unknown>>`, and `InferToolContext` saw only the erased `$ZodObject<$ZodShape>` → map slots resolved to `never` → every consumer needed `ctx.local as X` and `context: map as any`. Typed tool context is a headline feature; the types didn't help. (agent-monorepo pr-review FRICTION #2 — 2 casts; wikillm — 1.)

## Fix (types-only)

- `tool()` overloads carry a `TCtx` generic so the concrete schema type survives to the returned tool's `function.contextSchema`
- `ctx.local` is now `zodInfer<TCtx>` inside `execute`; `ToolContextMap` slots resolve to the real per-tool shape (and reject wrong shapes)
- Tools without a `contextSchema` keep `Record<string, never>` exactly as before

### Type-mechanics worth reviewing
Preserving concrete types exposed strict-function-types contravariance against the wide `Tool` union (previously masked by full erasure). Restored assignability with the standard patterns:
- `contextSchema` is `readonly` (covariant `TCtx`)
- `execute`/`onToolCalled`/`onResponseReceived` use method syntax; `ToModelOutputFunction`/`NextTurnParamsFunctions`/`ToolApprovalCheck` use the `bivarianceHack` pattern — params positions check bivariantly, which erased types implicitly got before
- One sanctioned construction-time write cast for the readonly field in `tool()` (runtime unchanged)

### Typecheck coverage note
`pnpm typecheck` now includes the new type test file. Discovered while wiring: the existing `.test-d.ts` files were never actually typechecked (vitest typecheck config gap), and several fail `tsc` against the current `@openrouter/sdk` (pre-existing drift, e.g. `OutputServerToolItem` renamed). Only the new file is included, with a tsconfig note; fixing the others is out of scope here.

## Tests

`tests/unit/context-schema-inference.test-d.ts` — ctx.local inference, map accept/reject (incl. missing-key + per-slot in mixed arrays), no-schema unchanged, manual tools, wide-union assignability. Verified the gate goes red on a deliberate type error. Suite: 30 files / 315 tests, build + biome green.

Changeset: patch. Plan: agent-monorepo `planning/sdk-fix-plan.md` PR-3.
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->