### PR TITLE
feat(agent): versioned ConversationState serialization contract

### DIFF
--- a/.changeset/feat-versioned-state-contract.md
+++ b/.changeset/feat-versioned-state-contract.md
@@ -1,0 +1,10 @@
+---
+"@openrouter/agent": minor
+---
+
+Add a versioned `ConversationState` serialization contract.
+
+- Optional `version` field on `ConversationState` (absence means v1); `createInitialState` now stamps `version: 1`.
+- New helpers: `serializeConversationState` / `deserializeConversationState` (package root + `@openrouter/agent/conversation-state`).
+- Typed errors: `UnsupportedStateVersionError` (`{found, supported}`) and `InvalidStateError` for malformed payloads.
+- Compat policy: treat JSON as opaque; additive changes within a major; migrations run in `deserializeConversationState` on version bump. StateAccessor load/save is unchanged — helpers are opt-in wrappers over what consumers already do with `JSON.stringify`/`parse`.

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -95,12 +95,17 @@ export { isClaudeStyleMessages } from './lib/claude-type-guards.js';
 // Conversation state helpers
 export {
   appendToMessages,
+  CONVERSATION_STATE_VERSION,
   createInitialState,
   createRejectedResult,
   createUnsentResult,
+  deserializeConversationState,
   generateConversationId,
+  InvalidStateError,
   partitionToolCalls,
+  serializeConversationState,
   toolRequiresApproval,
+  UnsupportedStateVersionError,
   updateState,
 } from './lib/conversation-state.js';
 export type { GetResponseOptions } from './lib/model-result.js';

--- a/packages/agent/src/lib/conversation-state.ts
+++ b/packages/agent/src/lib/conversation-state.ts
@@ -58,13 +58,13 @@ export function generateConversationId(): string {
   return `conv_${Date.now()}_${Math.random().toString(36).substring(2, 15)}`;
 }
 
+/** Currently supported ConversationState serialization version. */
+export const CONVERSATION_STATE_VERSION = 1 as const;
+
 /**
  * Create an initial conversation state
  * @param id - Optional custom ID, generates one if not provided
  */
-/** Currently supported ConversationState serialization version. */
-export const CONVERSATION_STATE_VERSION = 1 as const;
-
 export function createInitialState<TTools extends readonly Tool[] = readonly Tool[]>(
   id?: string,
 ): ConversationState<TTools> {
@@ -175,6 +175,18 @@ export function deserializeConversationState<TTools extends readonly Tool[] = re
   if (typeof obj['status'] !== 'string') {
     throw new InvalidStateError(
       `ConversationState missing or invalid field "status" (expected string, got ${describeType(obj['status'])})`,
+    );
+  }
+
+  if (typeof obj['createdAt'] !== 'number') {
+    throw new InvalidStateError(
+      `ConversationState missing or invalid field "createdAt" (expected number, got ${describeType(obj['createdAt'])})`,
+    );
+  }
+
+  if (typeof obj['updatedAt'] !== 'number') {
+    throw new InvalidStateError(
+      `ConversationState missing or invalid field "updatedAt" (expected number, got ${describeType(obj['updatedAt'])})`,
     );
   }
 

--- a/packages/agent/src/lib/conversation-state.ts
+++ b/packages/agent/src/lib/conversation-state.ts
@@ -87,7 +87,12 @@ export class UnsupportedStateVersionError extends Error {
   readonly found: number;
   readonly supported: readonly number[];
 
-  constructor(found: number, supported: readonly number[] = [CONVERSATION_STATE_VERSION]) {
+  constructor(
+    found: number,
+    supported: readonly number[] = [
+      CONVERSATION_STATE_VERSION,
+    ],
+  ) {
     super(
       `Unsupported ConversationState version ${found}; supported version(s): ${supported.join(', ')}`,
     );
@@ -197,7 +202,9 @@ export function deserializeConversationState<TTools extends readonly Tool[] = re
         `ConversationState field "version" must be a number when present (got ${describeType(version)})`,
       );
     }
-    throw new UnsupportedStateVersionError(version, [CONVERSATION_STATE_VERSION]);
+    throw new UnsupportedStateVersionError(version, [
+      CONVERSATION_STATE_VERSION,
+    ]);
   }
 
   return {

--- a/packages/agent/src/lib/conversation-state.ts
+++ b/packages/agent/src/lib/conversation-state.ts
@@ -163,6 +163,21 @@ export function deserializeConversationState<TTools extends readonly Tool[] = re
 
   const obj = parsed as Record<string, unknown>;
 
+  // Version check runs before structural validation: a future-version blob may
+  // have a different shape, and it must fail with UnsupportedStateVersionError
+  // rather than a misleading InvalidStateError about v1 fields.
+  const version = obj['version'];
+  if (version !== undefined && version !== CONVERSATION_STATE_VERSION) {
+    if (typeof version !== 'number') {
+      throw new InvalidStateError(
+        `ConversationState field "version" must be a number when present (got ${describeType(version)})`,
+      );
+    }
+    throw new UnsupportedStateVersionError(version, [
+      CONVERSATION_STATE_VERSION,
+    ]);
+  }
+
   if (typeof obj['id'] !== 'string') {
     throw new InvalidStateError(
       `ConversationState missing or invalid field "id" (expected string, got ${describeType(obj['id'])})`,
@@ -195,18 +210,6 @@ export function deserializeConversationState<TTools extends readonly Tool[] = re
     );
   }
 
-  const version = obj['version'];
-  if (version !== undefined && version !== CONVERSATION_STATE_VERSION) {
-    if (typeof version !== 'number') {
-      throw new InvalidStateError(
-        `ConversationState field "version" must be a number when present (got ${describeType(version)})`,
-      );
-    }
-    throw new UnsupportedStateVersionError(version, [
-      CONVERSATION_STATE_VERSION,
-    ]);
-  }
-
   return {
     ...(obj as unknown as ConversationState<TTools>),
     version: CONVERSATION_STATE_VERSION,
@@ -229,7 +232,7 @@ function describeType(value: unknown): string {
  */
 export function updateState<TTools extends readonly Tool[] = readonly Tool[]>(
   state: ConversationState<TTools>,
-  updates: Partial<Omit<ConversationState<TTools>, 'id' | 'createdAt' | 'updatedAt'>>,
+  updates: Partial<Omit<ConversationState<TTools>, 'id' | 'createdAt' | 'updatedAt' | 'version'>>,
 ): ConversationState<TTools> {
   return {
     ...state,

--- a/packages/agent/src/lib/conversation-state.ts
+++ b/packages/agent/src/lib/conversation-state.ts
@@ -62,17 +62,146 @@ export function generateConversationId(): string {
  * Create an initial conversation state
  * @param id - Optional custom ID, generates one if not provided
  */
+/** Currently supported ConversationState serialization version. */
+export const CONVERSATION_STATE_VERSION = 1 as const;
+
 export function createInitialState<TTools extends readonly Tool[] = readonly Tool[]>(
   id?: string,
 ): ConversationState<TTools> {
   const now = Date.now();
   return {
+    version: CONVERSATION_STATE_VERSION,
     id: id ?? generateConversationId(),
     messages: [],
     status: 'in_progress',
     createdAt: now,
     updatedAt: now,
   };
+}
+
+/**
+ * Thrown when {@link deserializeConversationState} encounters a state blob whose
+ * `version` is not supported by this SDK build.
+ */
+export class UnsupportedStateVersionError extends Error {
+  readonly found: number;
+  readonly supported: readonly number[];
+
+  constructor(found: number, supported: readonly number[] = [CONVERSATION_STATE_VERSION]) {
+    super(
+      `Unsupported ConversationState version ${found}; supported version(s): ${supported.join(', ')}`,
+    );
+    this.name = 'UnsupportedStateVersionError';
+    this.found = found;
+    this.supported = supported;
+  }
+}
+
+/**
+ * Thrown when {@link deserializeConversationState} receives JSON that is not a
+ * well-formed ConversationState (missing/wrong required fields, or invalid JSON).
+ */
+export class InvalidStateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidStateError';
+  }
+}
+
+/**
+ * Serialize a {@link ConversationState} to a stable JSON string for durable storage.
+ *
+ * Guarantees the `version` field is present (injects `1` when the input state
+ * lacks it). Treat the returned JSON as **opaque**: consumers should round-trip
+ * via these helpers rather than introspecting item shapes.
+ *
+ * **Compat policy:** additive field changes within a major version. On version
+ * bumps, migrations run inside {@link deserializeConversationState}. The
+ * StateAccessor load/save contract is unchanged — these helpers are opt-in.
+ */
+export function serializeConversationState<TTools extends readonly Tool[] = readonly Tool[]>(
+  state: ConversationState<TTools>,
+): string {
+  return JSON.stringify({
+    ...state,
+    version: state.version ?? CONVERSATION_STATE_VERSION,
+  });
+}
+
+/**
+ * Parse and validate a previously serialized {@link ConversationState}.
+ *
+ * Accepts version-less legacy blobs and states with `version: 1`, normalizing
+ * both to `version: 1`. Throws {@link UnsupportedStateVersionError} for any
+ * other version (fail loudly so stores don't silently misinterpret future
+ * shapes). Throws {@link InvalidStateError} for malformed JSON or missing
+ * required fields (`id`, `messages`, `status`).
+ *
+ * **Compat policy:** absence of `version` means v1. Migrations for future
+ * versions happen here; callers should treat the JSON as opaque.
+ */
+export function deserializeConversationState<TTools extends readonly Tool[] = readonly Tool[]>(
+  json: string,
+): ConversationState<TTools> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (error) {
+    throw new InvalidStateError(
+      `Invalid ConversationState JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new InvalidStateError('ConversationState must be a JSON object');
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  if (typeof obj['id'] !== 'string') {
+    throw new InvalidStateError(
+      `ConversationState missing or invalid field "id" (expected string, got ${describeType(obj['id'])})`,
+    );
+  }
+
+  // messages is models.InputsUnion — typically an array of items, but the type
+  // also allows a single item / string; require array for durable store blobs.
+  if (!Array.isArray(obj['messages'])) {
+    throw new InvalidStateError(
+      `ConversationState missing or invalid field "messages" (expected array, got ${describeType(obj['messages'])})`,
+    );
+  }
+
+  if (typeof obj['status'] !== 'string') {
+    throw new InvalidStateError(
+      `ConversationState missing or invalid field "status" (expected string, got ${describeType(obj['status'])})`,
+    );
+  }
+
+  const version = obj['version'];
+  if (version !== undefined && version !== CONVERSATION_STATE_VERSION) {
+    if (typeof version !== 'number') {
+      throw new InvalidStateError(
+        `ConversationState field "version" must be a number when present (got ${describeType(version)})`,
+      );
+    }
+    throw new UnsupportedStateVersionError(version, [CONVERSATION_STATE_VERSION]);
+  }
+
+  return {
+    ...(obj as unknown as ConversationState<TTools>),
+    version: CONVERSATION_STATE_VERSION,
+  };
+}
+
+function describeType(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+  return typeof value;
 }
 
 /**

--- a/packages/agent/src/lib/tool-types.ts
+++ b/packages/agent/src/lib/tool-types.ts
@@ -1038,6 +1038,15 @@ export type ConversationStatus =
  * @template TTools - The tools array type for proper type inference
  */
 export interface ConversationState<TTools extends readonly Tool[] = readonly Tool[]> {
+  /**
+   * Serialization-contract version for this state blob.
+   *
+   * Optional so legacy (pre-version-field) states remain assignable. Absence is
+   * treated as version `1` by {@link deserializeConversationState}. Consumers
+   * should treat serialized JSON as opaque: additive fields within a major
+   * version, migrations applied inside `deserializeConversationState` on bump.
+   */
+  version?: number;
   /** Unique identifier for this conversation */
   id: string;
   /** Full message history */

--- a/packages/agent/tests/unit/conversation-state-serialization.test.ts
+++ b/packages/agent/tests/unit/conversation-state-serialization.test.ts
@@ -194,6 +194,35 @@ describe('ConversationState serialization contract (PR-6)', () => {
       expect((error as InvalidStateError).message).toMatch(/"status"/);
     }
 
+    try {
+      deserializeConversationState(
+        JSON.stringify({
+          id: 'conv_x',
+          messages: [],
+          status: 'in_progress',
+          updatedAt: 1,
+        }),
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidStateError);
+      expect((error as InvalidStateError).message).toMatch(/"createdAt"/);
+    }
+
+    try {
+      deserializeConversationState(
+        JSON.stringify({
+          id: 'conv_x',
+          messages: [],
+          status: 'in_progress',
+          createdAt: 1,
+          updatedAt: 'yesterday',
+        }),
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidStateError);
+      expect((error as InvalidStateError).message).toMatch(/"updatedAt"/);
+    }
+
     expect(() => deserializeConversationState('not-json{')).toThrow(InvalidStateError);
   });
 

--- a/packages/agent/tests/unit/conversation-state-serialization.test.ts
+++ b/packages/agent/tests/unit/conversation-state-serialization.test.ts
@@ -24,7 +24,7 @@ describe('ConversationState serialization contract (PR-6)', () => {
     expect(restored.version).toBe(1);
   });
 
-  it("round-trips a rich awaiting_client_tools state with pendingToolCalls", () => {
+  it('round-trips a rich awaiting_client_tools state with pendingToolCalls', () => {
     // Shape mirrors the frozen pending state produced after a manual-tool
     // pause (see manual-tool-pending-state.test.ts / PR-4).
     const rich: ConversationState = {
@@ -142,7 +142,9 @@ describe('ConversationState serialization contract (PR-6)', () => {
       expect(error).toBeInstanceOf(UnsupportedStateVersionError);
       const typed = error as UnsupportedStateVersionError;
       expect(typed.found).toBe(2);
-      expect(typed.supported).toEqual([1]);
+      expect(typed.supported).toEqual([
+        1,
+      ]);
       expect(typed.name).toBe('UnsupportedStateVersionError');
     }
   });

--- a/packages/agent/tests/unit/conversation-state-serialization.test.ts
+++ b/packages/agent/tests/unit/conversation-state-serialization.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CONVERSATION_STATE_VERSION,
+  createInitialState,
+  deserializeConversationState,
+  InvalidStateError,
+  serializeConversationState,
+  UnsupportedStateVersionError,
+} from '../../src/lib/conversation-state.js';
+import type { ConversationState } from '../../src/lib/tool-types.js';
+
+describe('ConversationState serialization contract (PR-6)', () => {
+  it('round-trips a fresh createInitialState with version 1', () => {
+    const state = createInitialState('conv_fresh');
+    expect(state.version).toBe(1);
+
+    const json = serializeConversationState(state);
+    const restored = deserializeConversationState(json);
+
+    expect(restored).toEqual({
+      ...state,
+      version: CONVERSATION_STATE_VERSION,
+    });
+    expect(restored.version).toBe(1);
+  });
+
+  it("round-trips a rich awaiting_client_tools state with pendingToolCalls", () => {
+    // Shape mirrors the frozen pending state produced after a manual-tool
+    // pause (see manual-tool-pending-state.test.ts / PR-4).
+    const rich: ConversationState = {
+      version: 1,
+      id: 'conv_manual_pause',
+      status: 'awaiting_client_tools',
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_500,
+      previousResponseId: 'resp_manual',
+      messages: [
+        {
+          type: 'message',
+          role: 'user',
+          content: 'run ls',
+        },
+        {
+          type: 'function_call',
+          id: 'fc_call_manual_1',
+          callId: 'call_manual_1',
+          name: 'exec_command',
+          arguments: '{"command":"ls"}',
+          status: 'completed',
+        },
+        {
+          type: 'function_call',
+          id: 'fc_call_auto_1',
+          callId: 'call_auto_1',
+          name: 'auto_search',
+          arguments: '{"query":"docs"}',
+          status: 'completed',
+        },
+        {
+          type: 'function_call_output',
+          id: 'output_call_auto_1',
+          callId: 'call_auto_1',
+          output: JSON.stringify({
+            result: 'found it',
+          }),
+        },
+      ],
+      pendingToolCalls: [
+        {
+          id: 'call_manual_1',
+          name: 'exec_command',
+          arguments: {
+            command: 'ls',
+          },
+        },
+      ],
+      unsentToolResults: [
+        {
+          callId: 'call_auto_1',
+          name: 'auto_search',
+          output: {
+            result: 'found it',
+          },
+        },
+      ],
+    };
+
+    const json = serializeConversationState(rich);
+    const restored = deserializeConversationState(json);
+
+    expect(restored).toEqual(rich);
+    expect(restored.status).toBe('awaiting_client_tools');
+    expect(restored.pendingToolCalls).toHaveLength(1);
+    expect(restored.pendingToolCalls?.[0]?.id).toBe('call_manual_1');
+    expect(restored.pendingToolCalls?.[0]?.name).toBe('exec_command');
+    expect(restored.messages).toHaveLength(4);
+    expect(restored.unsentToolResults?.[0]?.callId).toBe('call_auto_1');
+  });
+
+  it('deserializes version-less legacy JSON and normalizes to version 1', () => {
+    // Hand-written pre-version fixture (what consumers stored with JSON.stringify).
+    const legacyJson = JSON.stringify({
+      id: 'conv_legacy',
+      messages: [
+        {
+          type: 'message',
+          role: 'user',
+          content: 'hello from v0',
+        },
+      ],
+      status: 'complete',
+      createdAt: 1_600_000_000_000,
+      updatedAt: 1_600_000_000_100,
+      previousResponseId: 'resp_legacy',
+    });
+
+    const restored = deserializeConversationState(legacyJson);
+
+    expect(restored.version).toBe(1);
+    expect(restored.id).toBe('conv_legacy');
+    expect(restored.status).toBe('complete');
+    expect(restored.messages).toHaveLength(1);
+    expect(restored.previousResponseId).toBe('resp_legacy');
+  });
+
+  it('throws UnsupportedStateVersionError for version 2', () => {
+    const futureJson = JSON.stringify({
+      version: 2,
+      id: 'conv_future',
+      messages: [],
+      status: 'in_progress',
+      createdAt: 1,
+      updatedAt: 1,
+    });
+
+    expect(() => deserializeConversationState(futureJson)).toThrow(UnsupportedStateVersionError);
+
+    try {
+      deserializeConversationState(futureJson);
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnsupportedStateVersionError);
+      const typed = error as UnsupportedStateVersionError;
+      expect(typed.found).toBe(2);
+      expect(typed.supported).toEqual([1]);
+      expect(typed.name).toBe('UnsupportedStateVersionError');
+    }
+  });
+
+  it('throws InvalidStateError for malformed shapes', () => {
+    expect(() =>
+      deserializeConversationState(
+        JSON.stringify({
+          messages: [],
+          status: 'in_progress',
+        }),
+      ),
+    ).toThrow(InvalidStateError);
+
+    try {
+      deserializeConversationState(
+        JSON.stringify({
+          messages: [],
+          status: 'in_progress',
+        }),
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidStateError);
+      expect((error as InvalidStateError).message).toMatch(/"id"/);
+    }
+
+    try {
+      deserializeConversationState(
+        JSON.stringify({
+          id: 'conv_x',
+          messages: 'not-an-array',
+          status: 'in_progress',
+        }),
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidStateError);
+      expect((error as InvalidStateError).message).toMatch(/"messages"/);
+    }
+
+    try {
+      deserializeConversationState(
+        JSON.stringify({
+          id: 'conv_x',
+          messages: [],
+        }),
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidStateError);
+      expect((error as InvalidStateError).message).toMatch(/"status"/);
+    }
+
+    expect(() => deserializeConversationState('not-json{')).toThrow(InvalidStateError);
+  });
+
+  it('serialize injects version when input state lacks it', () => {
+    const versionless = {
+      id: 'conv_no_ver',
+      messages: [],
+      status: 'in_progress' as const,
+      createdAt: 42,
+      updatedAt: 43,
+    } satisfies ConversationState;
+
+    // Explicitly omit version at the type level and runtime.
+    expect('version' in versionless ? versionless.version : undefined).toBeUndefined();
+
+    const json = serializeConversationState(versionless);
+    const parsed = JSON.parse(json) as {
+      version: number;
+    };
+    expect(parsed.version).toBe(1);
+
+    const restored = deserializeConversationState(json);
+    expect(restored.version).toBe(1);
+    expect(restored.id).toBe('conv_no_ver');
+  });
+});

--- a/packages/agent/tests/unit/conversation-state-serialization.test.ts
+++ b/packages/agent/tests/unit/conversation-state-serialization.test.ts
@@ -149,6 +149,21 @@ describe('ConversationState serialization contract (PR-6)', () => {
     }
   });
 
+  it('throws UnsupportedStateVersionError for version 2 even when the shape changed', () => {
+    // A version bump may rename/remove v1 fields; the version guard must run
+    // before structural validation so consumers get the version signal, not a
+    // misleading corruption error.
+    const reshapedFutureJson = JSON.stringify({
+      version: 2,
+      conversationId: 'conv_future',
+      history: [],
+    });
+
+    expect(() => deserializeConversationState(reshapedFutureJson)).toThrow(
+      UnsupportedStateVersionError,
+    );
+  });
+
   it('throws InvalidStateError for malformed shapes', () => {
     expect(() =>
       deserializeConversationState(


### PR DESCRIPTION
## Problem

`ConversationState` round-trips through `JSON.stringify`/`parse` (how every durable-store consumer uses it — serverless cold-start resume, SQLite state stores), but there were no helpers, no version field, and no forward-compat guarantee on `messages` item shapes. Fine within one SDK version; unsafe for long-lived production stores. (agent-monorepo wikillm FRICTION #4; the #1 committed core item in the feature-parity plan.)

## Change

- `version?: 1` on `ConversationState` (optional so legacy blobs stay assignable — absence means v1); `createInitialState` stamps `version: 1`
- New exports (package root + `/conversation-state` subpath):
  - `serializeConversationState(state)` — JSON with `version` guaranteed present
  - `deserializeConversationState(json)` — parse + shape validation; `undefined`/`1` accepted and normalized; other versions throw `UnsupportedStateVersionError({found, supported})`; malformed shape throws `InvalidStateError` naming the field
  - `CONVERSATION_STATE_VERSION` constant
- Documented compat policy: additive within a major; migrations live in `deserializeConversationState` on version bump; consumers treat the JSON as opaque
- **StateAccessor / ModelResult save path unchanged** — these are opt-in helpers formalizing what consumers already do

## Tests

6 new cases: fresh + rich round-trips (incl. `awaiting_client_tools` + `pendingToolCalls` from #64), version-less legacy fixture loads, `version: 2` fails loudly, malformed shapes fail loudly, serialize injects version. Suite: 30 files / 321 tests green.

Changeset: minor. Plan: agent-monorepo `planning/sdk-fix-plan.md` PR-6 (sequenced after #64 as planned).
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->