### PR TITLE
fix(agent): default final-answer directive for bare allowFinalResponse: true (DEV-658)

### DIFF
--- a/.agents/skills/public-api-examples/SKILL.md
+++ b/.agents/skills/public-api-examples/SKILL.md
@@ -32,7 +32,9 @@ const result = client.callModel({
   input: 'Research the topic step by step.',
   tools: [searchTool],
   stopWhen: stepCountIs(3),
-  allowFinalResponse: true, // new: appends DEFAULT_FINAL_RESPONSE_DIRECTIVE on the final no-tools turn
+  // new: default-on final turn with toolChoice:'none' appends
+  // DEFAULT_FINAL_RESPONSE_DIRECTIVE; `false` opts out
+  // allowFinalResponse: false,
 });
 ```
 

--- a/.agents/skills/public-api-examples/SKILL.md
+++ b/.agents/skills/public-api-examples/SKILL.md
@@ -1,0 +1,56 @@
+# Public API Changes Require a Code Example
+
+## Rule
+
+Any PR that changes the public API of `@openrouter/agent` (or any published package in this repo) MUST include a fenced code example block showing the change from the consumer's perspective. No example, no merge.
+
+## What Counts as a Public API Change
+
+- Adding, removing, or renaming an export in `src/index.ts` or any `exports` entry in `package.json`
+- Changing the signature, accepted values, or type of an exported function, option, or constant
+- Changing the *behavior* of an existing option — even when the type signature is unchanged (e.g. a default that used to append nothing now appends a message)
+- Adding or changing fields on serialized shapes consumers persist (`ConversationState`, tool result items)
+
+Internal refactors, test-only changes, and docs-only changes are exempt.
+
+## Where the Example Must Live
+
+| Location | Required | Notes |
+|---|---|---|
+| PR description | Always | A `### API example` section with a ` ```ts ` block. Show usage, not diff hunks. For behavioral changes, annotate old vs. new behavior in comments. |
+| Changeset (`.changeset/*.md`) | Always | Changesets become `CHANGELOG.md` via `@changesets/changelog-github`; the example makes the changelog self-documenting for consumers who never see the PR. |
+| README | When the touched API is documented there | Update the existing section; don't add a parallel one. |
+| JSDoc on the export | New exports and changed option semantics | The IDE hover is the API's first documentation surface. |
+
+## Example Template
+
+```ts
+import { callModel, stepCountIs } from '@openrouter/agent';
+
+const result = client.callModel({
+  model: 'z-ai/glm-5.2',
+  input: 'Research the topic step by step.',
+  tools: [searchTool],
+  stopWhen: stepCountIs(3),
+  allowFinalResponse: true, // new: appends DEFAULT_FINAL_RESPONSE_DIRECTIVE on the final no-tools turn
+});
+```
+
+Good examples:
+- Compile against the current branch (crib from a test you wrote — every API change already has one)
+- Show the *changed* surface, not the whole feature
+- Annotate behavioral deltas in comments (`// was: …`, `// now: …`)
+- Fit in ~15 lines; link to README/tests for the full picture
+
+## Reviewer Checklist
+
+1. Does the diff touch `src/index.ts`, `package.json#exports`, or the observable contract of anything exported?
+2. If yes: PR description has an `### API example` block, and the changeset contains an example.
+3. Does the example actually exercise the changed surface (not just adjacent code)?
+4. For behavioral changes to existing options: does the example or changeset state the old behavior and the migration/opt-out path?
+
+## Why
+
+- Reviewers judge API ergonomics from usage, not from implementation diffs
+- The changeset example flows into `CHANGELOG.md`, so npm consumers get migration guidance without spelunking PRs
+- Writing the example surfaces awkward APIs before they ship — if the example is hard to write, the API is wrong

--- a/.changeset/final-response-default-directive.md
+++ b/.changeset/final-response-default-directive.md
@@ -1,8 +1,8 @@
 ---
-'@openrouter/agent': patch
+'@openrouter/agent': minor
 ---
 
-`allowFinalResponse: true` now appends a built-in final-answer directive (exported as `DEFAULT_FINAL_RESPONSE_DIRECTIVE`) as the final user message on the forced no-tools turn. Previously bare `true` stripped tools but gave the model no signal that this was its last turn, so models that emit tool-call syntax as text (e.g. GLM) would attempt another tool call and leak unparsed `<tool_call>…` text into the final content (DEV-658).
+The forced final turn after `stopWhen` halts mid-tool-call is now **on by default** and uses `toolChoice: 'none'` instead of stripping `tools` (stripping busted the prompt-cache prefix). It appends a built-in final-answer directive (exported as `DEFAULT_FINAL_RESPONSE_DIRECTIVE`) as the final user message. Previously the final turn required opting in via `allowFinalResponse`, stripped the tools block, and bare `true` appended no directive — models that emit tool-call syntax as text (e.g. GLM) would attempt another tool call and leak unparsed `<tool_call>…` text into the final content (DEV-658).
 
 ```ts
 callModel(client, {
@@ -10,14 +10,19 @@ callModel(client, {
   input: 'Research this step by step.',
   tools: [searchTool],
   stopWhen: stepCountIs(3),
-  allowFinalResponse: true,
-  // was: final turn sent with tools stripped and NO directive — GLM-style
-  //      models could leak raw `<tool_call>…` text as the final answer
-  // now: appends DEFAULT_FINAL_RESPONSE_DIRECTIVE as a final user message
+  // was: no final turn unless allowFinalResponse was set; bare `true`
+  //      stripped tools (cache-busting) and appended no directive, so
+  //      GLM-style models could leak raw `<tool_call>…` as the answer
+  // now: default-on final turn with toolChoice:'none' (tools kept, cache
+  //      preserved) + DEFAULT_FINAL_RESPONSE_DIRECTIVE user message
 
   // custom wording still overrides the default:
   // allowFinalResponse: 'Summarize what you found.',
-  // legacy no-message behavior remains available as an explicit opt-out:
+  // append no message (turn still happens):
   // allowFinalResponse: '',
+  // restore the old opt-out (no final turn, run ends on the tool-call turn):
+  // allowFinalResponse: false,
 });
 ```
+
+Note: runs that previously ended on a halted tool-call turn now make one additional model request by default. Pass `allowFinalResponse: false` to keep the old behavior.

--- a/.changeset/final-response-default-directive.md
+++ b/.changeset/final-response-default-directive.md
@@ -2,4 +2,22 @@
 '@openrouter/agent': patch
 ---
 
-`allowFinalResponse: true` now appends a built-in final-answer directive (exported as `DEFAULT_FINAL_RESPONSE_DIRECTIVE`) as the final user message on the forced no-tools turn. Previously bare `true` stripped tools but gave the model no signal that this was its last turn, so models that emit tool-call syntax as text (e.g. GLM) would attempt another tool call and leak unparsed `<tool_call>…` text into the final content (DEV-658). A non-empty string still overrides the directive wording; pass `''` to append no message (the previous bare-`true` behavior).
+`allowFinalResponse: true` now appends a built-in final-answer directive (exported as `DEFAULT_FINAL_RESPONSE_DIRECTIVE`) as the final user message on the forced no-tools turn. Previously bare `true` stripped tools but gave the model no signal that this was its last turn, so models that emit tool-call syntax as text (e.g. GLM) would attempt another tool call and leak unparsed `<tool_call>…` text into the final content (DEV-658).
+
+```ts
+callModel(client, {
+  model: 'z-ai/glm-5.2',
+  input: 'Research this step by step.',
+  tools: [searchTool],
+  stopWhen: stepCountIs(3),
+  allowFinalResponse: true,
+  // was: final turn sent with tools stripped and NO directive — GLM-style
+  //      models could leak raw `<tool_call>…` text as the final answer
+  // now: appends DEFAULT_FINAL_RESPONSE_DIRECTIVE as a final user message
+
+  // custom wording still overrides the default:
+  // allowFinalResponse: 'Summarize what you found.',
+  // legacy no-message behavior remains available as an explicit opt-out:
+  // allowFinalResponse: '',
+});
+```

--- a/.changeset/final-response-default-directive.md
+++ b/.changeset/final-response-default-directive.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/agent': patch
+---
+
+`allowFinalResponse: true` now appends a built-in final-answer directive (exported as `DEFAULT_FINAL_RESPONSE_DIRECTIVE`) as the final user message on the forced no-tools turn. Previously bare `true` stripped tools but gave the model no signal that this was its last turn, so models that emit tool-call syntax as text (e.g. GLM) would attempt another tool call and leak unparsed `<tool_call>…` text into the final content (DEV-658). A non-empty string still overrides the directive wording; pass `''` to append no message (the previous bare-`true` behavior).

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -196,15 +196,19 @@ callModel(client, {
   input: 'Research this topic',
   tools: [searchTool] as const,
   stopWhen: stepCountIs(5),
-  allowFinalResponse: 'Please summarize what you found.',
-  // or just: allowFinalResponse: true
+  allowFinalResponse: true,
+  // or override the default directive:
+  // allowFinalResponse: 'Please summarize what you found.',
 });
 ```
 
 The pending tool calls from the halted turn are executed first so they
 have real outputs in the input, then the full conversation and the
-original `instructions` are sent to the model with no tools defined. A
-non-empty string value is appended as a final `user` message. Any
+original `instructions` are sent to the model with no tools defined.
+`true` appends a built-in final-answer directive as a `user` message
+(exported as `DEFAULT_FINAL_RESPONSE_DIRECTIVE`) so the model writes an
+answer instead of attempting another tool call; a non-empty string
+replaces the default wording; `''` appends no message. Any
 non-executable (manual) tool calls in the halted turn are paired with
 synthesized stub `function_call_output` items so the input is well-formed.
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -187,8 +187,12 @@ Built-in stop conditions:
 
 **Final response after stop**
 
-When `stopWhen` fires while the model is still emitting tool calls, pass
-`allowFinalResponse` to force one more model turn with no tools:
+When `stopWhen` fires while the model is still emitting tool calls, the
+loop makes one more model turn with `toolChoice: 'none'` so the run ends
+with a natural-language answer instead of a half-finished tool call.
+Tools stay in the request — only calling is forbidden — which preserves
+the prompt-cache prefix. **This is on by default**; `allowFinalResponse`
+tunes it:
 
 ```typescript
 callModel(client, {
@@ -196,19 +200,22 @@ callModel(client, {
   input: 'Research this topic',
   tools: [searchTool] as const,
   stopWhen: stepCountIs(5),
-  allowFinalResponse: true,
-  // or override the default directive:
+  // default (omitted or `true`): appends DEFAULT_FINAL_RESPONSE_DIRECTIVE
+  // as a final user message so the model writes an answer instead of
+  // attempting another tool call
+
+  // override the directive wording:
   // allowFinalResponse: 'Please summarize what you found.',
+  // append no message (turn still happens, calls still forbidden):
+  // allowFinalResponse: '',
+  // disable the final turn entirely:
+  // allowFinalResponse: false,
 });
 ```
 
 The pending tool calls from the halted turn are executed first so they
 have real outputs in the input, then the full conversation and the
-original `instructions` are sent to the model with no tools defined.
-`true` appends a built-in final-answer directive as a `user` message
-(exported as `DEFAULT_FINAL_RESPONSE_DIRECTIVE`) so the model writes an
-answer instead of attempting another tool call; a non-empty string
-replaces the default wording; `''` appends no message. Any
+original `instructions` are sent with `toolChoice: 'none'`. Any
 non-executable (manual) tool calls in the halted turn are paired with
 synthesized stub `function_call_output` items so the input is well-formed.
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -146,7 +146,7 @@ export type {
 } from './lib/hooks-types.js';
 export { HookName, isAsyncOutput } from './lib/hooks-types.js';
 export type { GetResponseOptions } from './lib/model-result.js';
-export { ModelResult } from './lib/model-result.js';
+export { DEFAULT_FINAL_RESPONSE_DIRECTIVE, ModelResult } from './lib/model-result.js';
 // Next turn params helpers
 export {
   applyNextTurnParamsToRequest,

--- a/packages/agent/src/inner-loop/call-model.ts
+++ b/packages/agent/src/inner-loop/call-model.ts
@@ -70,12 +70,14 @@ export type { CallModelInput } from '../lib/async-params.js';
  *
  * **Final Response After Stop:**
  *
- * When `stopWhen` fires while the model is still emitting tool calls, set
- * `allowFinalResponse: true` (or a string) to force one final model turn
- * with no tools so the loop ends with a natural-language summary rather
- * than a half-finished tool call. `true` appends a default final-answer
- * directive as a user message; a non-empty string replaces the default
- * wording; `''` appends nothing.
+ * When `stopWhen` fires while the model is still emitting tool calls, the
+ * loop makes one final model turn with `toolChoice: 'none'` (tools stay in
+ * the request to preserve the prompt cache) so the run ends with a
+ * natural-language answer rather than a half-finished tool call. This is
+ * the default; `allowFinalResponse` tunes it: `true`/omitted appends a
+ * default final-answer directive as a user message, a non-empty string
+ * replaces the wording, `''` appends nothing, `false` disables the final
+ * turn entirely.
  */
 export function callModel<
   TTools extends readonly Tool[],

--- a/packages/agent/src/inner-loop/call-model.ts
+++ b/packages/agent/src/inner-loop/call-model.ts
@@ -73,8 +73,9 @@ export type { CallModelInput } from '../lib/async-params.js';
  * When `stopWhen` fires while the model is still emitting tool calls, set
  * `allowFinalResponse: true` (or a string) to force one final model turn
  * with no tools so the loop ends with a natural-language summary rather
- * than a half-finished tool call. A string value is appended as a final
- * user message.
+ * than a half-finished tool call. `true` appends a default final-answer
+ * directive as a user message; a non-empty string replaces the default
+ * wording; `''` appends nothing.
  */
 export function callModel<
   TTools extends readonly Tool[],

--- a/packages/agent/src/lib/async-params.ts
+++ b/packages/agent/src/lib/async-params.ts
@@ -88,10 +88,14 @@ type BaseCallModelInput<
    * have matching outputs) and then make one more model request with no
    * tools so the model produces a final text response.
    *
-   * - `true` (or `''`) — re-prompt with the accumulated conversation and no
-   *   tools.
-   * - non-empty string — additionally append that string as a final user
-   *   message (e.g. `"Please summarize what you've learned"`).
+   * - `true` — re-prompt with the accumulated conversation, no tools, and a
+   *   default final-answer directive appended as a user message
+   *   (`DEFAULT_FINAL_RESPONSE_DIRECTIVE`). Without the directive, models
+   *   that emit tool-call syntax as text may leak an unparsed tool call
+   *   into the final content.
+   * - non-empty string — append that string as the final user message
+   *   instead of the default (e.g. `"Please summarize what you've learned"`).
+   * - `''` — no final user message; tools are still stripped.
    *
    * The full accumulated input array and the original `instructions` are
    * sent. Manual (non-executable) tool calls in the halted turn are paired

--- a/packages/agent/src/lib/async-params.ts
+++ b/packages/agent/src/lib/async-params.ts
@@ -85,17 +85,22 @@ type BaseCallModelInput<
   /**
    * When the loop exits because `stopWhen` was met and the last response
    * still contained tool calls, execute those pending tool calls (so they
-   * have matching outputs) and then make one more model request with no
-   * tools so the model produces a final text response.
+   * have matching outputs) and then make one more model request with
+   * `toolChoice: 'none'` so the model produces a final text response.
+   * Tools stay in the request — only calling is forbidden — so the
+   * prompt-cache prefix is preserved.
    *
-   * - `true` — re-prompt with the accumulated conversation, no tools, and a
+   * **Default: on.** Omitting the option behaves like `true`.
+   *
+   * - `true` / omitted — re-prompt with the accumulated conversation and a
    *   default final-answer directive appended as a user message
    *   (`DEFAULT_FINAL_RESPONSE_DIRECTIVE`). Without the directive, models
    *   that emit tool-call syntax as text may leak an unparsed tool call
    *   into the final content.
    * - non-empty string — append that string as the final user message
    *   instead of the default (e.g. `"Please summarize what you've learned"`).
-   * - `''` — no final user message; tools are still stripped.
+   * - `''` — no final user message; tool calls are still forbidden.
+   * - `false` — no final turn; the run ends on the halted tool-call turn.
    *
    * The full accumulated input array and the original `instructions` are
    * sent. Manual (non-executable) tool calls in the halted turn are paired
@@ -212,7 +217,7 @@ export async function resolveAsyncFunctions<TTools extends readonly Tool[] = rea
     'sharedContextSchema', // Client-side schema for shared context validation
     'onTurnStart', // Client-side turn start callback
     'onTurnEnd', // Client-side turn end callback
-    'allowFinalResponse', // Client-side: triggers no-tools final turn when stopWhen breaks the loop
+    'allowFinalResponse', // Client-side: tunes the default toolChoice:'none' final turn when stopWhen breaks the loop
     'strictFinalResponse', // Client-side: restore throw on empty final after tool rounds
     'hooks', // Client-side hook system
   ]);

--- a/packages/agent/src/lib/model-result.ts
+++ b/packages/agent/src/lib/model-result.ts
@@ -84,11 +84,12 @@ import {
 import { normalizeInputToArray } from './turn-context.js';
 
 /**
- * Default directive appended as a final user message when
- * `allowFinalResponse: true` forces the no-tools final turn. Stripping tools
- * alone is not enough: models that emit tool-call syntax as text (e.g. GLM)
- * will attempt another call and leak it into `content` as unparsed
- * `<tool_call>…` text unless they are told this is the final turn.
+ * Default directive appended as a final user message on the forced final
+ * turn (`allowFinalResponse` defaulting to on, or explicitly `true`).
+ * Forbidding tools via `toolChoice: 'none'` alone is not enough: models
+ * that emit tool-call syntax as text (e.g. GLM) will attempt another call
+ * and leak it into `content` as unparsed `<tool_call>…` text unless they
+ * are told this is the final turn.
  * Pass a non-empty string to `allowFinalResponse` to override the wording,
  * or `''` to append no message at all (legacy behavior).
  */
@@ -2150,18 +2151,19 @@ export class ModelResult<
   }
 
   /**
-   * Make a final no-tools request to coerce a text response after the loop
-   * was halted by `stopWhen` mid-tool-call. Reuses the resolved request so
-   * `instructions`, `model`, and other API fields ride along unchanged.
-   * `tools`, `toolChoice`, and `parallelToolCalls` are stripped — the whole
-   * point is to force a text turn. The caller is expected to have already
+   * Make a final no-tool-calls request to coerce a text response after the
+   * loop was halted by `stopWhen` mid-tool-call. Reuses the resolved request
+   * so `instructions`, `model`, and other API fields ride along unchanged.
+   * `tools` stays in the request with `toolChoice: 'none'` — forbidding
+   * calls while keeping the prompt-cache prefix intact (stripping the tools
+   * block would bust the cache). The caller is expected to have already
    * executed the pending tool calls and to pass their outputs in
    * `toolOutputs` so every function_call in the input has a matching output.
    */
   private async makeFinalResponseRequest(
     currentResponse: models.OpenResponsesResult,
     toolOutputs: models.FunctionCallOutputItem[],
-    allowFinalResponse: boolean | string,
+    allowFinalResponse: boolean | string | undefined,
     turnNumber: number,
   ): Promise<models.OpenResponsesResult> {
     if (!this.resolvedRequest) {
@@ -2180,10 +2182,13 @@ export class ModelResult<
           ]
         : [];
 
-    // Bare `true` gets the built-in directive; a non-empty string overrides
-    // the wording; `''` appends nothing (explicit opt-out).
+    // Default-on (`undefined`) and bare `true` get the built-in directive;
+    // a non-empty string overrides the wording; `''` appends nothing
+    // (explicit opt-out).
     const finalDirective =
-      allowFinalResponse === true ? DEFAULT_FINAL_RESPONSE_DIRECTIVE : allowFinalResponse;
+      allowFinalResponse === true || allowFinalResponse === undefined
+        ? DEFAULT_FINAL_RESPONSE_DIRECTIVE
+        : allowFinalResponse;
 
     const newInput: models.InputsUnion = [
       ...normalizedOriginalInput,
@@ -2203,15 +2208,13 @@ export class ModelResult<
         : []),
     ];
 
-    const {
-      tools: _tools,
-      toolChoice: _toolChoice,
-      parallelToolCalls: _parallelToolCalls,
-      ...rest
-    } = this.resolvedRequest;
-
     const finalRequest: models.ResponsesRequest = {
-      ...rest,
+      ...this.resolvedRequest,
+      // Forbid tool calls without dropping the tools block: removing
+      // `tools` would invalidate the prompt-cache prefix.
+      ...(this.resolvedRequest.tools !== undefined && {
+        toolChoice: 'none' as const,
+      }),
       input: newInput,
       stream: true,
     };
@@ -2261,27 +2264,24 @@ export class ModelResult<
    * Re-send the current resolved request (same accumulated input) once.
    * Used when a follow-up after tool execution returned an empty `output`.
    *
-   * `tools`, `toolChoice`, and `parallelToolCalls` are stripped (mirroring
+   * `toolChoice` is forced to `'none'` when tools are present (mirroring
    * `makeFinalResponseRequest`) so the retry coerces a text turn: on the
    * natural-loop-completion path the resolved request still carries tools,
    * and a retry that emitted a fresh `function_call` would pass
    * `validateFinalResponse` but never be executed — silently dropping a
-   * proposed tool call.
+   * proposed tool call. Tools stay in the request to keep the prompt-cache
+   * prefix intact.
    */
   private async retryCurrentRequest(turnNumber: number): Promise<models.OpenResponsesResult> {
     if (!this.resolvedRequest) {
       throw new Error('Request not initialized');
     }
 
-    const {
-      tools: _tools,
-      toolChoice: _toolChoice,
-      parallelToolCalls: _parallelToolCalls,
-      ...rest
-    } = this.resolvedRequest;
-
     const newRequest: models.ResponsesRequest = {
-      ...rest,
+      ...this.resolvedRequest,
+      ...(this.resolvedRequest.tools !== undefined && {
+        toolChoice: 'none' as const,
+      }),
       stream: true,
     };
 
@@ -3204,12 +3204,11 @@ export class ModelResult<
 
         // If stopWhen broke the loop while the model was still emitting tool
         // calls, execute those tool calls so they have matching outputs, then
-        // make one more no-tools request to coerce a final text response. An
-        // empty string still counts as "on" — it just means "don't append a
-        // user message."
+        // make one more `toolChoice: 'none'` request to coerce a final text
+        // response. Default-on: `undefined`, `true`, and any string enable
+        // it (`''` means "don't append a user message"); `false` opts out.
         const allowFinalResponse = this.options.allowFinalResponse;
-        const finalResponseEnabled =
-          allowFinalResponse === true || typeof allowFinalResponse === 'string';
+        const finalResponseEnabled = allowFinalResponse !== false;
         const pendingToolCalls = stoppedByStopWhen
           ? extractToolCallsFromResponse(currentResponse)
           : [];
@@ -3247,15 +3246,15 @@ export class ModelResult<
           await this.saveToolResultsToState(toolResults);
 
           if (pausedCalls.length > 0) {
-            // HITL paused — persist and exit without making the final no-tools
-            // request. The conversation will resume via the normal awaiting_hitl
-            // flow.
+            // HITL paused — persist and exit without making the final
+            // text-coercion request. The conversation will resume via the
+            // normal awaiting_hitl flow.
             await this.persistHitlPause(currentResponse, pausedCalls);
             return;
           }
 
           // Apply any nextTurnParams from the executed tools so they affect the
-          // final no-tools request (mirrors the in-loop behavior).
+          // final text-coercion request (mirrors the in-loop behavior).
           await this.applyNextTurnParams(pendingToolCalls);
 
           // Pair any manual tool calls (no execute fn) with stub outputs so

--- a/packages/agent/src/lib/model-result.ts
+++ b/packages/agent/src/lib/model-result.ts
@@ -84,6 +84,18 @@ import {
 import { normalizeInputToArray } from './turn-context.js';
 
 /**
+ * Default directive appended as a final user message when
+ * `allowFinalResponse: true` forces the no-tools final turn. Stripping tools
+ * alone is not enough: models that emit tool-call syntax as text (e.g. GLM)
+ * will attempt another call and leak it into `content` as unparsed
+ * `<tool_call>…` text unless they are told this is the final turn.
+ * Pass a non-empty string to `allowFinalResponse` to override the wording,
+ * or `''` to append no message at all (legacy behavior).
+ */
+export const DEFAULT_FINAL_RESPONSE_DIRECTIVE =
+  'You have reached the tool-use limit, and tools are no longer available. Do not attempt to call any more tools. Using the information you already have, write your final answer now.';
+
+/**
  * Typeguard for plain-object records (non-null, non-array).
  */
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -2168,6 +2180,11 @@ export class ModelResult<
           ]
         : [];
 
+    // Bare `true` gets the built-in directive; a non-empty string overrides
+    // the wording; `''` appends nothing (explicit opt-out).
+    const finalDirective =
+      allowFinalResponse === true ? DEFAULT_FINAL_RESPONSE_DIRECTIVE : allowFinalResponse;
+
     const newInput: models.InputsUnion = [
       ...normalizedOriginalInput,
       ...(Array.isArray(currentResponse.output)
@@ -2176,11 +2193,11 @@ export class ModelResult<
             currentResponse.output,
           ]),
       ...toolOutputs,
-      ...(typeof allowFinalResponse === 'string' && allowFinalResponse.length > 0
+      ...(typeof finalDirective === 'string' && finalDirective.length > 0
         ? [
             {
               role: 'user' as const,
-              content: allowFinalResponse,
+              content: finalDirective,
             },
           ]
         : []),

--- a/packages/agent/tests/e2e/call-model.test.ts
+++ b/packages/agent/tests/e2e/call-model.test.ts
@@ -1892,13 +1892,14 @@ describe('callModel E2E Tests', () => {
       expect(text.length).toBeGreaterThan(0);
     }, 30000);
 
-    // Regression: DEV-658. Bare `allowFinalResponse: true` used to strip
-    // tools on the forced final turn without telling the model it was the
-    // last turn. Models that emit tool-call syntax as text (GLM) would
-    // attempt another call and leak unparsed `<tool_call>…` into content.
-    // Reproduced 3/3 on the legacy path (`allowFinalResponse: ''`) and 0/3
-    // with the default directive — this test discriminates the fix.
-    it('DEV-658: bare true must not leak raw tool-call syntax on GLM', {
+    // Regression: DEV-658. The forced final turn used to strip tools and
+    // append no directive, so models that emit tool-call syntax as text
+    // (GLM) would attempt another call and leak unparsed `<tool_call>…`
+    // into content. Reproduced 3/3 on the legacy path (no directive) and
+    // 0/3 with the directive — this test discriminates the fix. The final
+    // turn now keeps tools with `toolChoice: 'none'` and is on by default,
+    // so the option is deliberately omitted here.
+    it('DEV-658: default final turn must not leak raw tool-call syntax on GLM', {
       retry: 1,
       timeout: 120000,
     }, async () => {
@@ -1930,7 +1931,7 @@ describe('callModel E2E Tests', () => {
           searchTool,
         ] as const,
         stopWhen: stepCountIs(1),
-        allowFinalResponse: true,
+        // allowFinalResponse omitted — default-on path under test
       });
 
       const finalResponse = await response.getResponse();

--- a/packages/agent/tests/e2e/call-model.test.ts
+++ b/packages/agent/tests/e2e/call-model.test.ts
@@ -1892,6 +1892,63 @@ describe('callModel E2E Tests', () => {
       expect(text.length).toBeGreaterThan(0);
     }, 30000);
 
+    // Regression: DEV-658. Bare `allowFinalResponse: true` used to strip
+    // tools on the forced final turn without telling the model it was the
+    // last turn. Models that emit tool-call syntax as text (GLM) would
+    // attempt another call and leak unparsed `<tool_call>…` into content.
+    // Reproduced 3/3 on the legacy path (`allowFinalResponse: ''`) and 0/3
+    // with the default directive — this test discriminates the fix.
+    it('DEV-658: bare true must not leak raw tool-call syntax on GLM', {
+      retry: 1,
+      timeout: 120000,
+    }, async () => {
+      const leakPattern = /<tool_call|<\|tool|<tool▁|\[TOOL_CALL\]|<function=/i;
+      const searchTool = {
+        type: ToolType.Function,
+        function: {
+          name: 'web_search',
+          description: 'Search the web for information.',
+          inputSchema: z.object({
+            query: z.string(),
+          }),
+          outputSchema: z.object({
+            results: z.string(),
+          }),
+          // Unhelpful results pressure the model to try another search on
+          // the final turn — the exact condition that leaked pre-fix.
+          execute: async (params: { query: string }) => ({
+            results: `No useful results for "${params.query}". Try a refined query.`,
+          }),
+        },
+      } as const;
+
+      const response = client.callModel({
+        model: 'z-ai/glm-5.2',
+        input:
+          'Find the year in which the architect who designed the main library of the university where the 2019 Nobel laureate in Economics (the one born in Mumbai) earned his PhD was born. Research step by step with web searches and verify each fact.',
+        tools: [
+          searchTool,
+        ] as const,
+        stopWhen: stepCountIs(1),
+        allowFinalResponse: true,
+      });
+
+      const finalResponse = await response.getResponse();
+      const text = await response.getText();
+
+      // A real answer, not an empty turn.
+      expect(text.length).toBeGreaterThan(0);
+      // No unparsed tool-call syntax leaked into content.
+      expect(text).not.toMatch(leakPattern);
+      // The forced final turn produced no structured tool calls either.
+      const outputItems = Array.isArray(finalResponse.output)
+        ? finalResponse.output
+        : [
+            finalResponse.output,
+          ];
+      expect(outputItems.filter((item) => item?.type === 'function_call')).toHaveLength(0);
+    });
+
     it('should append string allowFinalResponse as a user message', async () => {
       const response = client.callModel({
         model: 'anthropic/claude-haiku-4.5',

--- a/packages/agent/tests/unit/allow-final-response.test.ts
+++ b/packages/agent/tests/unit/allow-final-response.test.ts
@@ -10,6 +10,7 @@ vi.mock('@openrouter/sdk/funcs/betaResponsesSend', () => ({
 }));
 
 import { callModel } from '../../src/inner-loop/call-model.js';
+import { DEFAULT_FINAL_RESPONSE_DIRECTIVE } from '../../src/lib/model-result.js';
 import { stepCountIs } from '../../src/lib/stop-conditions.js';
 import { ToolType } from '../../src/lib/tool-types.js';
 
@@ -184,6 +185,15 @@ describe('allowFinalResponse', () => {
     // The tool's execute fn returned { temperature: 22 } — that's the real
     // output, NOT a stub.
     expect(fnCallOutput?.output).toContain('"temperature":22');
+    // Bare `true` appends the built-in final-answer directive as the last
+    // user message so tool-syntax-emitting models don't leak an unparsed
+    // tool call into content (DEV-658).
+    const lastItem = input[input.length - 1] as {
+      role?: string;
+      content?: string;
+    };
+    expect(lastItem.role).toBe('user');
+    expect(lastItem.content).toBe(DEFAULT_FINAL_RESPONSE_DIRECTIVE);
   });
 
   it('appends a non-empty string allowFinalResponse as a user message', async () => {

--- a/packages/agent/tests/unit/allow-final-response.test.ts
+++ b/packages/agent/tests/unit/allow-final-response.test.ts
@@ -107,7 +107,7 @@ describe('allowFinalResponse', () => {
     mockBetaResponsesSend.mockReset();
   });
 
-  it('makes a no-tools follow-up request when stopWhen halts mid-tool-call', async () => {
+  it("makes a toolChoice:'none' follow-up request when stopWhen halts mid-tool-call", async () => {
     mockBetaResponsesSend
       .mockResolvedValueOnce({
         ok: true,
@@ -138,10 +138,10 @@ describe('allowFinalResponse', () => {
 
     const secondCallRequest = mockBetaResponsesSend.mock.calls[1]?.[1]?.responsesRequest;
     expect(secondCallRequest).toBeDefined();
-    // Tool-related fields are stripped.
-    expect(secondCallRequest).not.toHaveProperty('tools');
-    expect(secondCallRequest).not.toHaveProperty('toolChoice');
-    expect(secondCallRequest).not.toHaveProperty('parallelToolCalls');
+    // Tools stay in the request (prompt-cache prefix preserved); calling is
+    // forbidden via toolChoice, overriding the caller's 'required'.
+    expect(secondCallRequest).toHaveProperty('tools');
+    expect(secondCallRequest.toolChoice).toBe('none');
     // Instructions ride along.
     expect(secondCallRequest.instructions).toBe('You are a weather assistant.');
     // Input contains the function_call from the halted turn AND a matching
@@ -188,6 +188,40 @@ describe('allowFinalResponse', () => {
     // Bare `true` appends the built-in final-answer directive as the last
     // user message so tool-syntax-emitting models don't leak an unparsed
     // tool call into content (DEV-658).
+    const lastItem = input[input.length - 1] as {
+      role?: string;
+      content?: string;
+    };
+    expect(lastItem.role).toBe('user');
+    expect(lastItem.content).toBe(DEFAULT_FINAL_RESPONSE_DIRECTIVE);
+  });
+
+  it('is on by default: omitted allowFinalResponse still makes the final turn with the directive', async () => {
+    mockBetaResponsesSend
+      .mockResolvedValueOnce({
+        ok: true,
+        value: toolCallResponse(),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: textResponse('Final summary.'),
+      });
+
+    const text = await callModel(client, {
+      model: 'test-model',
+      input: 'What is the weather?',
+      tools: [
+        weatherTool,
+      ] as const,
+      stopWhen: stepCountIs(0),
+      // allowFinalResponse deliberately omitted
+    }).getText();
+
+    expect(text).toBe('Final summary.');
+    expect(mockBetaResponsesSend).toHaveBeenCalledTimes(2);
+    const secondCallRequest = mockBetaResponsesSend.mock.calls[1]?.[1]?.responsesRequest;
+    expect(secondCallRequest.toolChoice).toBe('none');
+    const input = secondCallRequest?.input as unknown[];
     const lastItem = input[input.length - 1] as {
       role?: string;
       content?: string;

--- a/packages/agent/tests/unit/model-result-hooks.test.ts
+++ b/packages/agent/tests/unit/model-result-hooks.test.ts
@@ -149,6 +149,7 @@ function buildModelResult<T extends readonly Tool[]>(opts: {
   hooks?: HooksManager;
   state?: StateAccessor<T>;
   requireApproval?: (tc: ParsedToolCall<T[number]>, ctx: TurnContext) => boolean | Promise<boolean>;
+  allowFinalResponse?: boolean | string;
 }): ModelResult<T> {
   const config: Record<string, unknown> = {
     request: {
@@ -168,6 +169,9 @@ function buildModelResult<T extends readonly Tool[]>(opts: {
   }
   if (opts.requireApproval) {
     config['requireApproval'] = opts.requireApproval;
+  }
+  if (opts.allowFinalResponse !== undefined) {
+    config['allowFinalResponse'] = opts.allowFinalResponse;
   }
   return new ModelResult<T>(config as unknown as ConstructorParameters<typeof ModelResult<T>>[0]);
 }
@@ -886,6 +890,10 @@ describe('ModelResult hooks integration', () => {
           tool,
         ] as const,
         hooks,
+        // This test drives executeToolsIfNeeded directly without initStream,
+        // so the default-on final-response turn (which needs resolvedRequest)
+        // must be disabled; the subject here is the forceResume cap.
+        allowFinalResponse: false,
       });
       const ent = internal(m);
       ent.currentState = {

--- a/packages/agent/tests/unit/tool-terminal-empty-final.test.ts
+++ b/packages/agent/tests/unit/tool-terminal-empty-final.test.ts
@@ -189,7 +189,7 @@ describe('tool-terminal empty final response (PR-2)', () => {
     expect(mockBetaResponsesSend).toHaveBeenCalledTimes(3);
   });
 
-  it('strips tools from the empty-final retry so it cannot emit an unexecuted tool call', async () => {
+  it("forces toolChoice:'none' on the empty-final retry so it cannot emit an unexecuted tool call", async () => {
     mockBetaResponsesSend
       .mockResolvedValueOnce({
         ok: true,
@@ -213,15 +213,17 @@ describe('tool-terminal empty final response (PR-2)', () => {
     }).getText();
 
     expect(text).toBe('Done posting.');
-    // The natural-loop follow-up request still carries tools…
+    // The natural-loop follow-up request carries tools with the caller's
+    // toolChoice…
     const followupRequest = mockBetaResponsesSend.mock.calls[1]?.[1]?.responsesRequest;
     expect(followupRequest).toHaveProperty('tools');
-    // …but the retry must not, so it coerces a text turn instead of a
-    // fresh function_call that would be silently dropped.
+    expect(followupRequest.toolChoice).not.toBe('none');
+    // …the retry keeps tools (prompt-cache prefix) but forbids calling, so
+    // it coerces a text turn instead of a fresh function_call that would be
+    // silently dropped.
     const retryRequest = mockBetaResponsesSend.mock.calls[2]?.[1]?.responsesRequest;
-    expect(retryRequest).not.toHaveProperty('tools');
-    expect(retryRequest).not.toHaveProperty('toolChoice');
-    expect(retryRequest).not.toHaveProperty('parallelToolCalls');
+    expect(retryRequest).toHaveProperty('tools');
+    expect(retryRequest.toolChoice).toBe('none');
     expect(retryRequest.input).toEqual(followupRequest.input);
   });
 
@@ -254,7 +256,8 @@ describe('tool-terminal empty final response (PR-2)', () => {
     const finalRequest = mockBetaResponsesSend.mock.calls[1]?.[1]?.responsesRequest;
     const retryRequest = mockBetaResponsesSend.mock.calls[2]?.[1]?.responsesRequest;
     expect(retryRequest).toEqual(finalRequest);
-    expect(retryRequest).not.toHaveProperty('tools');
+    expect(retryRequest).toHaveProperty('tools');
+    expect(retryRequest.toolChoice).toBe('none');
     expect(retryRequest.input).toEqual(
       expect.arrayContaining([
         expect.objectContaining({


### PR DESCRIPTION
Fixes [DEV-658](https://linear.app/openrouter/issue/DEV-658/agent-sdk-bare-allowfinalresponse-true-can-emit-raw-tool-call-as)

## Problem

When `stopWhen` halted the loop mid-tool-call, the forced final turn stripped `tools`/`toolChoice`/`parallelToolCalls` and appended **no signal** that this was the model's last turn. Two defects:

1. **Leak (DEV-658):** models that emit tool-call syntax as text (GLM) attempt another tool call, which leaks into `content` as unparsed `<tool_call>…` text and gets treated as the final answer. Router PR #29461 worked around it by passing a directive *string*; every consumer using bare `true` was still exposed.
2. **Cache bust (review feedback):** stripping the `tools` block invalidated the prompt-cache prefix on the final request.

Additionally, the final turn was opt-in — the common failure mode (run ends on a half-finished tool call) was the default.

## Change

- **Final turn is on by default.** `allowFinalResponse: false` opts out; omitted/`true` behave identically.
- **Tools are kept; calling is forbidden** via `toolChoice: 'none'` — preserves the prompt-cache prefix. Same on the empty-final retry path (`retryCurrentRequest`).
- **Default directive:** omitted/`true` appends `DEFAULT_FINAL_RESPONSE_DIRECTIVE` (exported) as the final user message; a non-empty string overrides the wording; `''` appends nothing.

JSDoc, README, and changeset updated. Changeset bumped to **minor**: runs that previously ended on a halted tool-call turn now make one additional model request by default.

### API example

```ts
import { callModel, stepCountIs, DEFAULT_FINAL_RESPONSE_DIRECTIVE } from '@openrouter/agent';

const result = callModel(client, {
  model: 'z-ai/glm-5.2',
  input: 'Research this step by step.',
  tools: [searchTool],
  stopWhen: stepCountIs(3),
  // was: no final turn unless allowFinalResponse was set; bare `true`
  //      stripped tools (cache-busting) and appended no directive, so
  //      GLM-style models could leak raw `<tool_call>…` as the answer
  // now: default-on final turn with toolChoice:'none' (tools kept, cache
  //      preserved) + DEFAULT_FINAL_RESPONSE_DIRECTIVE user message

  // custom wording still overrides the default:
  // allowFinalResponse: 'Summarize what you found.',
  // append no message (turn still happens):
  // allowFinalResponse: '',
  // restore the old opt-out (no final turn):
  // allowFinalResponse: false,
});
```

## Tests

**Unit** (`allow-final-response.test.ts`, `tool-terminal-empty-final.test.ts`): final request keeps `tools` and forces `toolChoice: 'none'` (overriding the caller's `'required'`); default-on path (option omitted) makes the final turn with the directive; string override, `''`, and `false` contracts pinned; retry path asserts tools kept + `toolChoice: 'none'`.

**e2e regression** (`call-model.test.ts`): DEV-658 repro shape — `z-ai/glm-5.2`, a `web_search` tool returning deliberately unhelpful results, `stopWhen: stepCountIs(1)`, **option omitted** (default path under test). Asserts non-empty final text, no leaked tool-call syntax, zero structured `function_call` items.

Discrimination check (probed live before writing the test): legacy no-directive path leaked **3/3** runs; with the directive **0/3**.

## Verification

- Unit: 521/521, typecheck clean, biome clean
- e2e: full `allowFinalResponse` block passes against the live API (4/4, incl. GLM regression on the default path)
- CI e2e job verified actually running after provisioning the `OPENROUTER_API_KEY` repo secret (was previously skip-passing)

## Maintenance

Adds `.agents/skills/public-api-examples/SKILL.md`: public-API-changing PRs must carry a consumer-perspective code example in the PR description and changeset.

## Follow-up (not this PR)

- [DEV-660](https://linear.app/openrouter/issue/DEV-660/remove-server-tools-allowfinalresponse-workaround-after-sdk-fix-ships): drop the router-level `SERVER_TOOLS_FINAL_RESPONSE_DIRECTIVE` workaround once this ships
- Python/Go ports carry the same deficiencies (`model_result.py` `_build_final_request`, `model_result.go` `sendFinalResponseRequest`) — same fix shape applies
