### PR TITLE
[cortex smoke] add fetchWithRetry helper — validation PR, will be closed

### DIFF
--- a/scratch/cortex-smoke-retry.ts
+++ b/scratch/cortex-smoke-retry.ts
@@ -1,0 +1,15 @@
+/**
+ * TEMPORARY cortex live-review smoke file. This PR is closed immediately
+ * after the review posts; do not merge.
+ */
+export async function fetchWithRetry(url: string, attempts = 10): Promise<Response> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return res;
+    } catch {}
+    // fixed one-second wait between tries
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error("exhausted retries");
+}


### PR DESCRIPTION
End-to-end validation of the cortex review agent with REVIEW_DRY_RUN=0. Expect an automated review citing okf-0021. This PR will be closed without merging.
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->