### PR TITLE
[cortex smoke] config store — format validation, will be closed

### DIFF
--- a/scratch/cortex-smoke-config.ts
+++ b/scratch/cortex-smoke-config.ts
@@ -1,0 +1,22 @@
+/** TEMPORARY cortex format-validation smoke. Closed after review; do not merge. */
+export class ConfigStore {
+  private cache: Record<string, string> = {};
+  async load(url: string): Promise<void> {
+    const res = await fetch(url);
+    const text = await res.text();
+    // parse KEY=VALUE lines
+    for (const line of text.split("\n")) {
+      const [k, v] = line.split("=");
+      this.cache[k] = v; // no validation, k may be undefined
+    }
+  }
+  get(key: string): string {
+    return this.cache[key]; // lies about nullability
+  }
+  async loadAll(urls: string[]): Promise<void> {
+    for (const u of urls) await this.load(u); // serial, no error isolation
+  }
+  merge(other: ConfigStore): void {
+    for (const k in other.cache) this.cache[k] = other.cache[k]; // prototype pollution vector via __proto__ key
+  }
+}


### PR DESCRIPTION
Validates the reworked review-body format (badge list, no tables). Will be closed unmerged.
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->