### PR TITLE
[cortex smoke] duration parser — link validation, will be closed

### DIFF
--- a/scratch/cortex-smoke-duration.ts
+++ b/scratch/cortex-smoke-duration.ts
@@ -1,0 +1,7 @@
+/** TEMPORARY cortex link-validation smoke. Closed after review; do not merge. */
+export function parseDuration(input: string): number {
+  const n = parseInt(input); // no radix, accepts "12abc", NaN unchecked
+  if (input.endsWith("ms")) return n;
+  if (input.endsWith("s")) return n * 1000;
+  return n; // ambiguous default unit
+}


### PR DESCRIPTION
Validates blob-linked finding anchors. Will be closed unmerged.
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->