### PR TITLE
[cortex smoke] env bool parser — update-review validation, will be closed

### DIFF
--- a/scratch/cortex-smoke-envbool.ts
+++ b/scratch/cortex-smoke-envbool.ts
@@ -1,0 +1,4 @@
+/** TEMPORARY cortex update-review smoke. Closed after validation; do not merge. */
+export function parseEnvBool(value: string): boolean {
+  return Boolean(value); // "false" and "0" are truthy strings — always true for non-empty input
+}

--- a/scratch/cortex-smoke-envbool.ts
+++ b/scratch/cortex-smoke-envbool.ts
@@ -1,4 +1,5 @@
 /** TEMPORARY cortex update-review smoke. Closed after validation; do not merge. */
+const FALSY = new Set(["", "0", "false", "no", "off"]);
 export function parseEnvBool(value: string): boolean {
-  return Boolean(value); // "false" and "0" are truthy strings — always true for non-empty input
+  return !FALSY.has(value.trim().toLowerCase());
 }


### PR DESCRIPTION
Round 1 has a truthiness bug. A fix will be pushed to validate update reviews. Will be closed unmerged.
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->