### PR TITLE
[cortex smoke] member-approve validation, will be closed

### DIFF
--- a/scratch/cortex-smoke-gate2.ts
+++ b/scratch/cortex-smoke-gate2.ts
@@ -1,0 +1,7 @@
+/** TEMPORARY cortex gate smoke (member approve path). Closed after validation; do not merge. */
+const FALSY = new Set(["", "0", "false", "no", "off"]);
+
+/** Parse common environment-variable boolean spellings; unknown values default to true. */
+export function parseEnvBool(value: string): boolean {
+  return !FALSY.has(value.trim().toLowerCase());
+}


### PR DESCRIPTION
Author is a private org member; the authoritative membership check should allow a genuine APPROVE. Will be closed unmerged.
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->