### PR TITLE
Add parseEnvBool helper

### DIFF
--- a/scratch/env-bool.ts
+++ b/scratch/env-bool.ts
@@ -1,0 +1,6 @@
+const FALSY = new Set(["", "0", "false", "no", "off"]);
+
+/** Parse common environment-variable boolean spellings; unknown values default to true. */
+export function parseEnvBool(value: string): boolean {
+  return !FALSY.has(value.trim().toLowerCase());
+}


### PR DESCRIPTION
Small utility for parsing boolean environment variables. Handles the usual falsy spellings; defaults to true otherwise.
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->