### PR TITLE
fix(release): reset unpublished @openrouter/mcp to 0.0.1 for its first npm publish (DEV-684)

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openrouter/mcp
 
-## 0.2.0
+## 0.0.1
 
 ### Minor Changes
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@openrouter/mcp",
-  "version": "0.2.0",
-  "private": true,
+  "version": "0.0.1",
   "author": "OpenRouter",
   "description": "Expose remote MCP server tools (Streamable HTTP / SSE) as tools for @openrouter/agent's callModel, with serializable caching and pluggable auth.",
   "keywords": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@openrouter/mcp",
   "version": "0.2.0",
+  "private": true,
   "author": "OpenRouter",
   "description": "Expose remote MCP server tools (Streamable HTTP / SSE) as tools for @openrouter/agent's callModel, with serializable caching and pluggable auth.",
   "keywords": [


### PR DESCRIPTION
## Summary

- Resets `@openrouter/mcp` to `0.0.1` (package.json + changelog heading). The package has never been published — 0.1.0/0.2.0 only ever existed in-repo — and we want its first published version to be 0.0.1.
- Replaces the earlier `private: true` approach on this branch: we do want the package on npm, just starting at 0.0.1.
- Context: the `@openrouter/agent@0.8.0` release run ([29956743373](https://github.com/OpenRouterTeam/typescript-agent/actions/runs/29956743373)) 404'd creating `@openrouter/mcp` because the push-to-main publish leg uses npm trusted publishing (OIDC), which can't create a brand-new package.

## Publish plan (after merge)

1. Run **Actions → Release → Run workflow** with `mode: publish`. That path authenticates via the `NPM_TOKEN` secret (`NODE_AUTH_TOKEN` → setup-node `.npmrc`), so it can create the package — `changeset publish` will see local 0.0.1 ≠ npm and publish only mcp.
2. Configure GitHub Actions as a trusted publisher for `@openrouter/mcp` on npmjs.com so future push-to-main releases (OIDC) work.
3. If step 1 still 404s, the token lacks create-package rights on the `@openrouter` scope and an org owner needs to bootstrap it once.

Linear: [DEV-684](https://linear.app/openrouter/issue/DEV-684)

## Test plan

- [ ] CI (lint, typecheck, unit tests, structural gate, e2e) passes
- [ ] After merge: Release workflow `mode: publish` publishes `@openrouter/mcp@0.0.1` and skips `@openrouter/agent@0.8.0`
- [ ] Next push-to-main release exits 0