### PR TITLE
fix(release): use real npm trusted publishing (OIDC) for publish workflow

### DIFF
--- a/.agents/skills/changeset-versioning/SKILL.md
+++ b/.agents/skills/changeset-versioning/SKILL.md
@@ -5,8 +5,22 @@
 This repo uses [changesets](https://github.com/changesets/changesets) for version management and changelog generation.
 
 > **Publishing happens automatically on push to `main`.** `.github/workflows/publish.yaml` triggers on both `push: main` and `workflow_dispatch`. On a push with no pending changesets, `changesets/action` publishes any package whose local version is not yet on npm; with pending changesets it opens/updates the Version Packages PR instead. The `workflow_dispatch` modes below are for driving a release manually, not a gate that prevents automatic publishes.
->
-> This describes current behavior, which diverges from the original intent recorded in `@openrouter/agent@0.1.1` ("release-gate publishing via workflow_dispatch", [#4](https://github.com/OpenRouterTeam/typescript-agent/pull/4)) — the `push` leg has been passing `publish:` to `changesets/action` regardless. If the gate is wanted back, remove `publish:` from that step (or condition it on `workflow_dispatch`) rather than relying on this doc; note that the `npm-publish` environment currently has no protection rules, so nothing else stands between a merge and a live publish.
+
+This diverges from the original intent recorded in `@openrouter/agent@0.1.1` ("release-gate publishing via workflow_dispatch", [#4](https://github.com/OpenRouterTeam/typescript-agent/pull/4)): the `push` leg has been passing `publish:` to `changesets/action` regardless, so the gate has not been in effect. **Auto-publish is the intended behavior going forward** — the changeset flow already gates releases (no changeset means no version bump means nothing to publish), and the Version Packages PR is the human review point. To restore the old gate instead, condition the `publish:` input on `github.event_name == 'workflow_dispatch'`.
+
+### What actually protects a release
+
+The changeset flow controls *what* publishes; these control *who and from where*:
+
+| Control | Status |
+| --- | --- |
+| Version Packages PR review | Active — the human approval point for any version bump |
+| Job-level `if: github.ref == 'refs/heads/main'` | Active — blocks publishing from any non-`main` ref |
+| npm trusted publisher | Pins org, repo, workflow filename, environment. **No branch/ref claim exists**, so npm alone cannot restrict which branch publishes |
+| `npm-publish` deployment branch policy | **Not configured** (all branches allowed) |
+| `npm-publish` required reviewers | **Not configured** |
+
+Because npm's trusted publisher has no ref claim and the environment has no branch policy, the job-level `if` is what prevents a `workflow_dispatch` from an arbitrary branch reaching npm. Under token auth this mattered less; OIDC mints credentials on demand from any ref that reaches the workflow. Adding a branch policy (`main` only) and/or required reviewers to the `npm-publish` environment is the defense-in-depth follow-up — GitHub settings, not repo config.
 
 ## Why Coordinate Releases?
 

--- a/.agents/skills/changeset-versioning/SKILL.md
+++ b/.agents/skills/changeset-versioning/SKILL.md
@@ -5,6 +5,8 @@
 This repo uses [changesets](https://github.com/changesets/changesets) for version management and changelog generation.
 
 > **Publishing happens automatically on push to `main`.** `.github/workflows/publish.yaml` triggers on both `push: main` and `workflow_dispatch`. On a push with no pending changesets, `changesets/action` publishes any package whose local version is not yet on npm; with pending changesets it opens/updates the Version Packages PR instead. The `workflow_dispatch` modes below are for driving a release manually, not a gate that prevents automatic publishes.
+>
+> This describes current behavior, which diverges from the original intent recorded in `@openrouter/agent@0.1.1` ("release-gate publishing via workflow_dispatch", [#4](https://github.com/OpenRouterTeam/typescript-agent/pull/4)) — the `push` leg has been passing `publish:` to `changesets/action` regardless. If the gate is wanted back, remove `publish:` from that step (or condition it on `workflow_dispatch`) rather than relying on this doc; note that the `npm-publish` environment currently has no protection rules, so nothing else stands between a merge and a live publish.
 
 ## Why Coordinate Releases?
 

--- a/.agents/skills/changeset-versioning/SKILL.md
+++ b/.agents/skills/changeset-versioning/SKILL.md
@@ -69,7 +69,9 @@ Review and merge that PR to main.
 
 ### Step 2: Publish (pushes to npm)
 
-After the Version Packages PR is merged, go to **Actions → Release → Run workflow** and select:
+**Merging the Version Packages PR normally publishes on its own** — that merge is a push to `main`, which runs this workflow's `changesets/action` leg with `publish:` wired up. In the common case there is nothing to do here.
+
+This mode is for **retrying or forcing** a publish (for example after a failed run, or when a version is on disk but never reached npm). Go to **Actions → Release → Run workflow** and select:
 - **Mode:** `publish`
 - **Dry run:** unchecked (or check it first to verify)
 
@@ -112,7 +114,7 @@ The changelog is written to `CHANGELOG.md` during the version step.
 ## Configuration
 
 - `.changeset/config.json` — Changesets configuration
-- `.github/workflows/publish.yaml` — Release workflow (workflow_dispatch)
+- `.github/workflows/publish.yaml` — Release workflow (`push: main` + `workflow_dispatch`)
 - `.github/workflows/ci.yaml` — PR validation (lint, typecheck, test)
 
 ## Common Commands

--- a/.agents/skills/changeset-versioning/SKILL.md
+++ b/.agents/skills/changeset-versioning/SKILL.md
@@ -2,11 +2,15 @@
 
 ## Overview
 
-This repo uses [changesets](https://github.com/changesets/changesets) for version management and changelog generation. Publishing is **release-gated** via `workflow_dispatch` — it does NOT auto-publish on push to main.
+This repo uses [changesets](https://github.com/changesets/changesets) for version management and changelog generation.
 
-## Why Release-Gated?
+> **Publishing happens automatically on push to `main`.** `.github/workflows/publish.yaml` triggers on both `push: main` and `workflow_dispatch`. On a push with no pending changesets, `changesets/action` publishes any package whose local version is not yet on npm; with pending changesets it opens/updates the Version Packages PR instead. The `workflow_dispatch` modes below are for driving a release manually, not a gate that prevents automatic publishes.
+
+## Why Coordinate Releases?
 
 `@openrouter/agent` depends on `@openrouter/sdk`. When Speakeasy regenerates SDK types, the agent must be updated to match. Both packages need **coordinated releases** — publishing one without the other can break consumers.
+
+Because a merge to `main` can publish, the coordination point is **when the Version Packages PR merges**, not a separate manual publish step. Hold that PR until the matching `@openrouter/sdk` release is out.
 
 ## Adding a Changeset
 
@@ -17,7 +21,7 @@ pnpm changeset add
 ```
 
 This will prompt you to:
-1. Select the package (`@openrouter/agent`)
+1. Select the package (`@openrouter/agent` and/or `@openrouter/mcp`)
 2. Choose a bump type (`patch`, `minor`, `major`)
 3. Write a summary of the change
 
@@ -51,13 +55,23 @@ After the Version Packages PR is merged, go to **Actions → Release → Run wor
 - **Mode:** `publish`
 - **Dry run:** unchecked (or check it first to verify)
 
-This runs `pnpm publish --provenance --access public` to push the new version to npm.
+This runs `pnpm exec changeset publish --no-git-checks` to push the new version to npm.
+
+Authentication uses [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) — there is no npm token in CI. Provenance attestations are generated automatically by npm and do not need a `--provenance` flag. This requires:
+
+- `id-token: write` permission on the job (already set).
+- Node 24+ on the runner, since OIDC needs npm >= 11.5.1 and Node 22 ships npm 10.x. A guard step fails the run early with a clear message if npm is too old.
+- A trusted publisher configured on npmjs.com for **each** package: repo `OpenRouterTeam/typescript-agent`, workflow filename `publish.yaml`, environment `npm-publish`. npm does not validate these fields on save, and all are case-sensitive — a mismatch only shows up as a failed publish (`ENEEDAUTH`, or `E404` on a `PUT`).
+
+A package's **first** version cannot be published via OIDC ([npm/cli#8544](https://github.com/npm/cli/issues/8544)); the npm UI requires the package to exist before a trusted publisher can be attached. Bootstrap a brand-new package with one manual `npm publish --access public`, then configure its trusted publisher.
 
 ### Dry Run
 
 To verify what would happen without making changes:
 - **Mode:** `publish`
 - **Dry run:** checked
+
+The dry run uses `pnpm -r publish --dry-run`, which simulates every workspace package rather than only the ones changesets would select, so its output set may be wider than a real publish. It also never reaches the OIDC token exchange, so it validates tarball contents — not authentication.
 
 ## Coordination with @openrouter/sdk
 
@@ -93,5 +107,5 @@ pnpm run build              # Build (tsc)
 pnpm run typecheck          # Type check without emitting
 pnpm run test               # Run unit tests
 pnpm run test:e2e           # Run e2e tests (requires OPENROUTER_API_KEY)
-pnpm lint                   # Lint with eslint
+pnpm run lint               # Lint with biome
 ```

--- a/.agents/skills/changeset-versioning/SKILL.md
+++ b/.agents/skills/changeset-versioning/SKILL.md
@@ -15,12 +15,14 @@ The changeset flow controls *what* publishes; these control *who and from where*
 | Control | Status |
 | --- | --- |
 | Version Packages PR review | Active — the human approval point for any version bump |
-| Job-level `if: github.ref == 'refs/heads/main'` | Active — blocks publishing from any non-`main` ref |
-| npm trusted publisher | Pins org, repo, workflow filename, environment. **No branch/ref claim exists**, so npm alone cannot restrict which branch publishes |
-| `npm-publish` deployment branch policy | **Not configured** (all branches allowed) |
+| Job-level ref guard (`publish.yaml`) | Active, but **accident-only** — `workflow_dispatch` runs the workflow file from the selected ref, so a branch whose copy drops the guard ignores it |
+| npm trusted publisher | Pins org, repo, workflow filename, environment. **No branch/ref claim exists**, so npm cannot restrict which branch publishes |
+| `npm-publish` deployment branch policy | **Not configured** (all branches allowed) — the only real server-side ref restriction |
 | `npm-publish` required reviewers | **Not configured** |
 
-Because npm's trusted publisher has no ref claim and the environment has no branch policy, the job-level `if` is what prevents a `workflow_dispatch` from an arbitrary branch reaching npm. Under token auth this mattered less; OIDC mints credentials on demand from any ref that reaches the workflow. Adding a branch policy (`main` only) and/or required reviewers to the `npm-publish` environment is the defense-in-depth follow-up — GitHub settings, not repo config.
+The job-level guard stops someone from mistakenly dispatching a release off `main`; it is not a security boundary, because the guard travels with the ref being dispatched. Since npm's trusted publisher carries no ref claim, **the `npm-publish` environment's deployment branch policy is the only server-side control over which branch can publish** — setting it to `main` is the actual fix, not merely defense-in-depth. This matters more under OIDC than it did under token auth, because credentials are now minted on demand from whatever ref reaches the workflow. Required reviewers on that environment are a further hardening step.
+
+The guard deliberately still allows `mode=publish` + `dry-run` from any branch, since that leg never reaches the OIDC exchange. It does **not** exempt `dry-run` generally: with `mode=version` the changesets step runs with `publish:` wired up and ignores `dry-run`, so a blanket exemption would let a feature branch publish for real.
 
 ## Why Coordinate Releases?
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,6 +64,20 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      # Fail fast with an actionable message if the runner's npm cannot do the
+      # OIDC exchange. Without this, an npm downgrade (e.g. someone lowers
+      # node-version) surfaces as a cryptic `E404 PUT` or `ENEEDAUTH` at publish
+      # time, which is what made the original breakage hard to diagnose.
+      - name: Verify npm supports trusted publishing
+        run: |
+          set -euo pipefail
+          NPM_VERSION="$(npm --version)"
+          echo "node $(node --version) / npm ${NPM_VERSION}"
+          if [ "$(printf '%s\n' "11.5.1" "${NPM_VERSION}" | sort -V | head -n1)" != "11.5.1" ]; then
+            echo "::error::npm ${NPM_VERSION} cannot use trusted publishing (OIDC); npm >= 11.5.1 is required. Raise node-version in this workflow."
+            exit 1
+          fi
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm run build

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,7 +34,7 @@ on:
 permissions:
   contents: write # For creating releases and the Version Packages PR
   pull-requests: write # For creating/updating the Version Packages PR
-  id-token: write # For npm provenance signing
+  id-token: write # For npm trusted publishing (OIDC) + provenance signing
 
 env:
   TURBO_TELEMETRY_DISABLED: '1'
@@ -48,11 +48,21 @@ jobs:
 
       - uses: pnpm/action-setup@v6
 
+      # npm trusted publishing (OIDC) requires npm >= 11.5.1, which means Node
+      # 24 — Node 22 ships npm 10.x, which has no OIDC token-exchange support at
+      # all and fails with ENEEDAUTH/E404. `pnpm publish` shells out to whichever
+      # `npm` is on PATH, so the Node version here is what performs the exchange.
+      #
+      # `registry-url` is deliberately omitted: it makes setup-node write an
+      # .npmrc containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`,
+      # and with no NODE_AUTH_TOKEN set that placeholder is left unexpanded and
+      # sent to the registry as a literal bearer token, breaking the `npm info`
+      # lookups changesets performs before publishing. npm's OIDC flow sets the
+      # auth token itself once the trusted publisher matches.
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
-          registry-url: https://registry.npmjs.org
 
       - run: pnpm install --frozen-lockfile
 
@@ -73,7 +83,10 @@ jobs:
           publish: pnpm exec changeset publish --no-git-checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # No NODE_AUTH_TOKEN / NPM_TOKEN: auth comes from OIDC trusted
+          # publishing. changesets/action logs "No NPM_TOKEN found, but OIDC is
+          # available" and leaves .npmrc alone; npm then exchanges the Actions
+          # ID token for a short-lived, package-scoped publish token.
 
       # Record the npm version before a manual publish so the dispatch step can
       # tell whether this run actually published a new @openrouter/agent (the
@@ -87,19 +100,18 @@ jobs:
       - name: Publish (workflow_dispatch, live)
         if: github.event_name == 'workflow_dispatch' && inputs.mode == 'publish' && !inputs.dry-run
         run: pnpm exec changeset publish --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # `changeset publish` has no native --dry-run. Fall back to pnpm's
       # recursive dry-run, which simulates publishing every workspace package
       # rather than only the ones changesets would pick. Output set may be
       # wider than the live publish — but nothing is actually published, so
       # this is only a diagnostic preview.
+      #
+      # Dry runs never reach the OIDC exchange, so they cannot verify auth —
+      # they only confirm which tarballs would go out.
       - name: Publish (workflow_dispatch, dry-run)
         if: github.event_name == 'workflow_dispatch' && inputs.mode == 'publish' && inputs.dry-run
-        run: pnpm -r publish --dry-run --access public --provenance --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm -r publish --dry-run --access public --no-git-checks
 
       # HOP B trigger: when @openrouter/agent is actually published, tell the
       # monorepo (openrouter-web) to bump its pinned @openrouter/agent for

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,7 +64,7 @@ jobs:
     if: >
       github.ref == 'refs/heads/main' ||
       (github.event_name == 'workflow_dispatch' &&
-       inputs.mode == 'publish' && inputs.dry-run)
+      inputs.mode == 'publish' && inputs.dry-run)
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,9 @@ on:
           - "publish" — Publishes every package whose on-disk version differs
             from npm, with provenance. Only run this AFTER the Version Packages
             PR has been merged to main.
+            Note: merging that PR normally publishes on its own, because this
+            workflow also runs on push to main. This mode is for retrying or
+            forcing a publish, not a required second step.
           NOTE: @openrouter/agent releases must be coordinated with @openrouter/sdk
           because callModel changes are typically coupled with SDK type changes.
         required: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,6 +46,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: npm-publish
+    # Publishing is only ever valid from main. npm's GitHub trusted publisher
+    # can only pin org/repo/workflow-filename/environment — it has no branch or
+    # ref claim — so OIDC alone would authorize a publish from any branch that
+    # can reach this workflow. The `npm-publish` environment currently has no
+    # deployment branch policy either, which would let a `workflow_dispatch`
+    # from an arbitrary branch publish to npm. This is the in-repo backstop.
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,13 +46,25 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: npm-publish
-    # Publishing is only ever valid from main. npm's GitHub trusted publisher
-    # can only pin org/repo/workflow-filename/environment — it has no branch or
-    # ref claim — so OIDC alone would authorize a publish from any branch that
-    # can reach this workflow. The `npm-publish` environment currently has no
-    # deployment branch policy either, which would let a `workflow_dispatch`
-    # from an arbitrary branch publish to npm. This is the in-repo backstop.
-    if: github.ref == 'refs/heads/main'
+    # Only publish from main, and allow dry-run diagnostics from any branch
+    # (that leg never reaches the OIDC exchange, so it cannot publish).
+    #
+    # This guards against *accidents*, not a determined actor: workflow_dispatch
+    # runs the workflow file from the selected ref, so a branch whose copy drops
+    # this line would ignore it. The only server-side ref restriction is the
+    # `npm-publish` environment's deployment branch policy, which is currently
+    # unset — and under OIDC that is the real control, because npm's trusted
+    # publisher pins org/repo/workflow-filename/environment and carries no
+    # branch or ref claim. Setting that policy to `main` is the actual fix.
+    #
+    # The off-main exemption is scoped to mode=publish + dry-run specifically.
+    # `dry-run` alone is not enough: with mode=version the changesets step runs
+    # with `publish:` wired up and ignores dry-run entirely, so `dry-run: true`
+    # from a feature branch could still publish for real.
+    if: >
+      github.ref == 'refs/heads/main' ||
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.mode == 'publish' && inputs.dry-run)
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Problem

The release workflow was never actually using OIDC, despite logging that it was.

`changesets/action@v1` decides its auth path by looking at `process.env.NPM_TOKEN` ([`src/index.ts:80-120`](https://github.com/changesets/action/blob/v1.9.0/src/index.ts)). The workflow passed the secret as `NODE_AUTH_TOKEN`, so the action took the "no token" branch and printed:

```
No NPM_TOKEN found, but OIDC is available - using npm trusted publishing
```

...while the credential actually in use was the `.npmrc` that `actions/setup-node` writes when given `registry-url`. That's how `@openrouter/agent@0.8.0` shipped (npm user `robertyeakel`, provenance from `publishConfig.provenance`, not from trusted publishing).

The `E404 ... PUT https://registry.npmjs.org/@openrouter%2fmcp` was that token lacking rights to create a new package name — npm answers 404, not 403, in that case.

Real OIDC couldn't have worked here regardless:

- `node-version: 22` ships **npm 10.x**, which has no `lib/utils/oidc.js` at all. Trusted publishing needs **npm >= 11.5.1 / Node >= 22.14** ([docs](https://docs.npmjs.com/trusted-publishers)).
- Trusted publishing also can't create a package's *first* version ([npm/cli#8544](https://github.com/npm/cli/issues/8544)). `@openrouter/mcp@0.0.1` has since been bootstrapped manually, so that blocker is cleared.

## Changes

- **Node 22 → 24** (npm 11.16.0). `pnpm publish` shells out to whichever `npm` is on `PATH` (`@pnpm/run-npm`), so the runner's npm is what performs the token exchange.
- **Removed `registry-url` and all `NODE_AUTH_TOKEN` wiring.** These have to go together: with `registry-url` set but no token in the environment, `@npmcli/config`'s `env-replace.js` leaves the literal `${NODE_AUTH_TOKEN}` in `.npmrc` and npm sends it as a bearer token, which 401s the `npm info` calls changesets makes before publishing. npm's OIDC flow sets the auth token itself (`lib/commands/publish.js:147`, before `getCredentialsByURI`).
- **Dropped `--provenance` from the dry-run step.** Trusted publishing attests automatically, and dry runs never reach the exchange.

## Required npm settings (not in this PR)

For **each** of `@openrouter/agent` and `@openrouter/mcp`, add a trusted publisher:

| Field | Value |
| --- | --- |
| Publisher | GitHub Actions |
| Organization | `OpenRouterTeam` |
| Repository | `typescript-agent` |
| Workflow filename | `publish.yaml` |
| Environment | `npm-publish` |
| Allowed actions | `npm publish` |

Or via CLI (npm >= 11.15, requires account-level 2FA):

```sh
npm trust github @openrouter/agent --repo OpenRouterTeam/typescript-agent \
  --file publish.yaml --env npm-publish --allow-publish
npm trust github @openrouter/mcp --repo OpenRouterTeam/typescript-agent \
  --file publish.yaml --env npm-publish --allow-publish
```

All fields are case-sensitive and npm does **not** validate them on save — a mismatch only surfaces as a failed publish.

## Verification

- Full `pnpm run build` + `pnpm run test` pass locally on Node 24.18.0 / npm 11.16.0 (both packages, all suites).
- `.github/workflows/publish.yaml` parses as valid YAML; confirmed no step retains `NODE_AUTH_TOKEN` and only `GITHUB_TOKEN` / `GH_TOKEN` env remain.
- `pnpm publish --dry-run` on `packages/mcp` produces a valid 82-file tarball with `@openrouter/agent` resolved to `0.8.0`.
- Confirmed `repository.url` in both package.json files matches the GitHub repo, which npm requires for OIDC publishes.

## Follow-ups

- Once a publish succeeds through OIDC, delete the `NPM_TOKEN` secret from the `npm-publish` environment and revoke the token on npm. Leaving it in place keeps the old attack surface open (and 2FA-bypass granular tokens are being deprecated for publishing).
- Consider setting each package to *"Require two-factor authentication and disallow tokens"* afterwards.
- `packages/*/publishConfig.provenance: true` is now redundant under trusted publishing but harmless; left alone to keep manual/local publishes attested where possible.

<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/82" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->