### PR TITLE
Add lastN helper (smoke)

### DIFF
--- a/scratch/last-n.ts
+++ b/scratch/last-n.ts
@@ -1,0 +1,5 @@
+/** Return the last n items of xs (scratch smoke file — PR will be closed unmerged). */
+export function lastN<T>(xs: T[], n: number): T[] {
+  if (n <= 0) return [];
+  return xs.slice(xs.length - n - 1);
+}


### PR DESCRIPTION
Scratch smoke validating the review-model change. Will be closed unmerged.
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->