### PR TITLE
feat(agent): add getUsage() aggregate usage accessor to ModelResult

### DIFF
--- a/.changeset/get-usage-accessor.md
+++ b/.changeset/get-usage-accessor.md
@@ -1,0 +1,11 @@
+---
+'@openrouter/agent': minor
+---
+
+New `ModelResult.getUsage()` accessor: aggregate token/cost usage across every model call a run made.
+
+`getResponse()` resolves to the *final* round's response, so in a multi-round tool loop the tokens spent on the intermediate `tool_calls` generations were unreachable — and `getItemsStream()` carries output items only, never surfacing the `response.completed` events that hold each round's usage block. Callers streaming items therefore had no way to account for a run's real token spend without registering a hook.
+
+`await result.getUsage()` returns the same `SessionUsageTotals` shape as the `SessionEnd` hook's `totalUsage` (`modelCalls`, `inputTokens`, `outputTokens`, `totalTokens`, `cachedTokens`, `reasoningTokens`, and `cost` when the server reported it), summed over the initial request, each tool-round follow-up, the empty-final retry, the `allowFinalResponse` final turn, and approval-resume requests. It gates on run completion like `getResponse()` does, so totals are final whether awaited directly, after `getResponse()`, or after draining any streaming getter — including `getItemsStream()`. Unlike `getResponse()` it never rejects (a failed run still consumed tokens), returning the totals accrued so far.
+
+The usage aggregate is now accumulated independently of the hook system, so it is correct for callers who configured no hooks at all; previously it only advanced as a side effect of `PostModelCall` emission. `SessionEnd.totalUsage` and `getUsage()` read from one snapshot helper and cannot drift.

--- a/.changeset/get-usage-accessor.md
+++ b/.changeset/get-usage-accessor.md
@@ -4,8 +4,24 @@
 
 New `ModelResult.getUsage()` accessor: aggregate token/cost usage across every model call a run made.
 
+```ts
+const result = callModel(client, { model, input, tools });
+
+for await (const item of result.getItemsStream()) {
+  render(item);
+}
+
+// new: aggregate totals across EVERY round of the tool loop
+const usage = await result.getUsage();
+console.log(usage.modelCalls, usage.totalTokens, usage.cost);
+
+// was (and still is): the FINAL round's response only
+const response = await result.getResponse();
+console.log(response.usage?.totalTokens);
+```
+
 `getResponse()` resolves to the *final* round's response, so in a multi-round tool loop the tokens spent on the intermediate `tool_calls` generations were unreachable — and `getItemsStream()` carries output items only, never surfacing the `response.completed` events that hold each round's usage block. Callers streaming items therefore had no way to account for a run's real token spend without registering a hook.
 
-`await result.getUsage()` returns the same `SessionUsageTotals` shape as the `SessionEnd` hook's `totalUsage` (`modelCalls`, `inputTokens`, `outputTokens`, `totalTokens`, `cachedTokens`, `reasoningTokens`, and `cost` when the server reported it), summed over the initial request, each tool-round follow-up, the empty-final retry, the `allowFinalResponse` final turn, and approval-resume requests. It gates on run completion like `getResponse()` does, so totals are final whether awaited directly, after `getResponse()`, or after draining any streaming getter — including `getItemsStream()`. Unlike `getResponse()` it never rejects (a failed run still consumed tokens), returning the totals accrued so far.
+`await result.getUsage()` returns the same `SessionUsageTotals` shape as the `SessionEnd` hook's `totalUsage` (`modelCalls`, `inputTokens`, `outputTokens`, `totalTokens`, `cachedTokens`, `reasoningTokens`, and `cost` when the server reported it), summed over the initial request, each tool-round follow-up, the empty-final retry, the `allowFinalResponse` final turn, and approval-resume requests. It gates on run completion like `getResponse()` does, so totals are final whether awaited directly, after `getResponse()`, or after draining any streaming getter — including `getItemsStream()` (on an approval-resumed run, reading usage never advances the tool loop; await `getResponse()`/`getText()` first for final totals there). Unlike `getResponse()` it never rejects (a failed run still consumed tokens), returning the totals accrued so far.
 
 The usage aggregate is now accumulated independently of the hook system, so it is correct for callers who configured no hooks at all; previously it only advanced as a side effect of `PostModelCall` emission. `SessionEnd.totalUsage` and `getUsage()` read from one snapshot helper and cannot drift.

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -68,9 +68,13 @@ const result = callModel(client, { model, input, tools });
 // Await the final text
 const text = await result.getText();
 
-// Await the full response with usage data
+// Await the full response with usage data (the FINAL round only)
 const response = await result.getResponse();
 console.log(response.usage); // { inputTokens, outputTokens, cost, ... }
+
+// Await aggregate usage across EVERY round of the tool loop
+const usage = await result.getUsage();
+console.log(usage); // { modelCalls, inputTokens, outputTokens, totalTokens, cachedTokens, reasoningTokens, cost? }
 
 // Stream text deltas
 for await (const delta of result.getTextStream()) {
@@ -109,8 +113,43 @@ What each stream emits:
 | `getReasoningStream()` | reasoning deltas |
 | `getToolStream()` | tool-call **argument deltas**; `preliminary_result` events for generator tools — *not* execution results |
 | `getToolCallsStream()` | parsed tool calls as they complete |
-| `getItemsStream()` | all output items (messages, function calls, …) |
-| `getFullResponsesStream()` | every response event, including `tool.result` / `tool.call_output` execution events |
+| `getItemsStream()` | all output items (messages, function calls, …) — output items **only**, no usage/response metadata |
+| `getFullResponsesStream()` | every response event, including `tool.result` / `tool.call_output` execution events, and each round's `response.completed` (with that round's usage block) |
+
+#### Usage across a multi-round tool loop
+
+`getResponse()` resolves to the **final** round's response, so in a
+multi-round tool loop the tokens spent on the intermediate `tool_calls`
+generations are not in `response.usage`. `getItemsStream()` carries output
+items only and never surfaces `response.completed`, so usage is not reachable
+from that stream either.
+
+`getUsage()` closes the gap with aggregate totals across every model call the
+run made — the initial request, each tool-round follow-up, the empty-final
+retry, the `allowFinalResponse` final turn, and approval-resume requests:
+
+```typescript
+const result = callModel(client, { model, input, tools });
+
+for await (const item of result.getItemsStream()) {
+  render(item);
+}
+
+const usage = await result.getUsage();
+console.log(usage.modelCalls, usage.totalTokens, usage.cost);
+```
+
+It gates on run completion like `getResponse()` does, so the totals are final
+whether you await it directly, after `getResponse()`, or after draining any of
+the streaming getters. Unlike `getResponse()` it never rejects — a failed run
+still consumed tokens — and returns the totals accrued so far, with
+`modelCalls: 0` and zeroed tokens when no model call completed. `cost` is
+present only when the server reported cost accounting.
+
+Same `SessionUsageTotals` shape and numbers as the `SessionEnd` hook's
+`totalUsage`. For **per-call** granularity use the `PostModelCall` hook (one
+emit per model call, with `turnType`/`turnNumber`) or read each round's
+`response.completed` off `getFullResponsesStream()`.
 
 ### Tool Types
 
@@ -534,6 +573,9 @@ a materialized response emits no `PostModelCall`; a `response.incomplete`
 response (e.g. truncated at `max_output_tokens`) **does** emit — it carries a
 real generation id and consumed tokens. Note `usage.cost` is only present when
 the request had usage accounting enabled server-side.
+
+`SessionEnd.totalUsage` is push-based; for the same totals without registering
+a hook, await [`getUsage()`](#usage-across-a-multi-round-tool-loop).
 Every handler receives `(payload, context)` — `context` carries the
 `sessionId` (the single source of session identity; payloads do not repeat
 it), the `hookName`, and an `AbortSignal` for cooperative cancellation. The

--- a/packages/agent/src/lib/model-result.ts
+++ b/packages/agent/src/lib/model-result.ts
@@ -26,7 +26,7 @@ import type {
 } from './doom-loop.js';
 import { DoomLoopMonitor, resolveDoomLoopOption, resolveLoopKeyMaterial } from './doom-loop.js';
 import type { HooksManager } from './hooks-manager.js';
-import type { ModelCallUsage, PostModelCallPayload } from './hooks-types.js';
+import type { ModelCallUsage, PostModelCallPayload, SessionUsageTotals } from './hooks-types.js';
 import {
   applyNextTurnParamsToRequest,
   executeNextTurnParamsFunctions,
@@ -1792,17 +1792,7 @@ export class ModelResult<
       {
         reason,
         ...(this.sessionUsage.modelCalls > 0 && {
-          totalUsage: {
-            modelCalls: this.sessionUsage.modelCalls,
-            inputTokens: this.sessionUsage.inputTokens,
-            outputTokens: this.sessionUsage.outputTokens,
-            totalTokens: this.sessionUsage.totalTokens,
-            cachedTokens: this.sessionUsage.cachedTokens,
-            reasoningTokens: this.sessionUsage.reasoningTokens,
-            ...(this.sessionUsage.hasCost && {
-              cost: this.sessionUsage.cost,
-            }),
-          },
+          totalUsage: this.snapshotSessionUsage(),
         }),
       },
       this.hookEmitContext(),
@@ -1810,8 +1800,35 @@ export class ModelResult<
   }
 
   /**
+   * Materialize the running session aggregate as an immutable
+   * `SessionUsageTotals`. `cost` is present only when at least one response
+   * reported it, matching the hook payload's optionality (a summed cost of
+   * `0` from cost-less responses would read as "free" rather than "unknown").
+   *
+   * Single source of truth for both `SessionEnd.totalUsage` and the public
+   * `getUsage()` accessor, so the two can never drift.
+   */
+  private snapshotSessionUsage(): SessionUsageTotals {
+    return {
+      modelCalls: this.sessionUsage.modelCalls,
+      inputTokens: this.sessionUsage.inputTokens,
+      outputTokens: this.sessionUsage.outputTokens,
+      totalTokens: this.sessionUsage.totalTokens,
+      cachedTokens: this.sessionUsage.cachedTokens,
+      reasoningTokens: this.sessionUsage.reasoningTokens,
+      ...(this.sessionUsage.hasCost && {
+        cost: this.sessionUsage.cost,
+      }),
+    };
+  }
+
+  /**
    * Emit PostModelCall for a completed model response and fold its usage
    * into the session aggregate. One emit per materialized response.
+   *
+   * Accumulation runs unconditionally — before the hooks short-circuit —
+   * because `getUsage()` surfaces these totals to callers who configured no
+   * hooks at all. Only the hook emit is gated on a `HooksManager`.
    */
   private async emitPostModelCall(
     response: models.OpenResponsesResult,
@@ -1819,9 +1836,6 @@ export class ModelResult<
     turnType: PostModelCallPayload['turnType'],
     turnNumber: number,
   ): Promise<void> {
-    if (!this.hooksManager) {
-      return;
-    }
     const usage = extractModelCallUsage(response.usage);
     this.sessionUsage.modelCalls++;
     if (usage) {
@@ -1834,6 +1848,9 @@ export class ModelResult<
         this.sessionUsage.cost += usage.cost;
         this.sessionUsage.hasCost = true;
       }
+    }
+    if (!this.hooksManager) {
+      return;
     }
     await this.hooksManager.emit(
       'PostModelCall',
@@ -1923,38 +1940,41 @@ export class ModelResult<
 
   /**
    * Session teardown for the no-tools stream paths, which bypass
-   * executeToolsIfNeeded (the normal SessionEnd site). Emits SessionEnd once
-   * and drains pending hook work. Never throws: teardown must not mask the
-   * stream's own outcome.
+   * executeToolsIfNeeded (the normal SessionEnd site). Materializes the
+   * parked model-call telemetry, emits SessionEnd once, and drains pending
+   * hook work. Never throws: teardown must not mask the stream's own outcome.
    */
   private async finishHooksSessionForStream(
     reason: 'complete' | 'error' = 'complete',
   ): Promise<void> {
+    // Materialize the parked initial-call telemetry when the stream fully
+    // completed (the retained buffer replays without touching the source).
+    // A failed/errored stream skips it: no materialized response exists.
+    // (`response.incomplete` responses DO emit — they are materialized, have
+    // a generation id, and consumed tokens.)
+    // Runs even without a HooksManager: this is the only site that folds the
+    // no-tools streaming response into `sessionUsage`, which `getUsage()`
+    // reports to hook-less callers.
+    // Isolated try: a telemetry failure (e.g. a buffer without a completion
+    // event, or a throwing strict-mode handler) must not skip SessionEnd or
+    // the drain below — those are contractual on every exit path.
+    try {
+      if (this.pendingModelCall) {
+        if (this.finalResponse) {
+          await this.emitPendingModelCallOnce(this.finalResponse);
+        } else if (this.reusableStream?.isComplete) {
+          await this.emitPendingModelCallOnce(
+            await consumeStreamForCompletion(this.reusableStream),
+          );
+        }
+      }
+    } catch (telemetryError) {
+      console.warn('[PostModelCall] error during stream teardown:', telemetryError);
+    }
     if (!this.hooksManager) {
       return;
     }
     try {
-      // Materialize the parked initial-call telemetry when the stream fully
-      // completed (the retained buffer replays without touching the source).
-      // A failed/errored stream skips it: no materialized response exists.
-      // (`response.incomplete` responses DO emit — they are materialized, have
-      // a generation id, and consumed tokens.)
-      // Isolated try: a telemetry failure (e.g. a buffer without a completion
-      // event, or a throwing strict-mode handler) must not skip SessionEnd or
-      // the drain below — those are contractual on every exit path.
-      try {
-        if (this.pendingModelCall) {
-          if (this.finalResponse) {
-            await this.emitPendingModelCallOnce(this.finalResponse);
-          } else if (this.reusableStream?.isComplete) {
-            await this.emitPendingModelCallOnce(
-              await consumeStreamForCompletion(this.reusableStream),
-            );
-          }
-        }
-      } catch (telemetryError) {
-        console.warn('[PostModelCall] error during stream teardown:', telemetryError);
-      }
       await this.emitSessionEndOnce(reason);
       await this.hooksManager.drain();
     } catch (teardownError) {
@@ -4292,6 +4312,17 @@ export class ModelResult<
    * - file_search_call: File search operations
    * - image_generation_call: Image generation operations
    * - function_call_output: Results from executed tools
+   *
+   * This stream carries **output items only** — no usage or response-level
+   * metadata. The `response.completed` events (which hold each round's usage
+   * block) are not surfaced here, and `getResponse()` afterwards returns only
+   * the *final* round's response, so a multi-round tool loop's `tool_calls`
+   * generations are not accounted for by either. For usage, reach for:
+   * - `getUsage()` — aggregate token/cost totals across every round
+   * - the `PostModelCall` hook — one emit per model call, with
+   *   `turnType`/`turnNumber` and that call's own `usage`
+   * - `getFullResponsesStream()` — raw events including each round's
+   *   `response.completed`, and therefore its per-round usage block
    */
   getItemsStream(): AsyncIterableIterator<StreamableOutputItem<TTools>> {
     // Build the allowed-item-type scope from the tools actually passed to
@@ -4869,5 +4900,51 @@ export class ModelResult<
       await this.executeToolsIfNeeded();
     }
     return this.doomLoopStop;
+  }
+
+  /**
+   * Aggregate token/cost usage across **every** model call this run made —
+   * the initial request, each tool-round follow-up, the empty-final retry,
+   * the `allowFinalResponse` final turn, and approval-resume requests.
+   *
+   * This is the pull-based counterpart to the `SessionEnd.totalUsage` hook
+   * payload (same `SessionUsageTotals` shape, same numbers) and exists
+   * because `getResponse()` returns only the **final** round's response: in a
+   * multi-round tool loop the `tool_calls` generations' tokens are otherwise
+   * unreachable, and `getItemsStream()` carries output items only — no
+   * `response.completed` usage block.
+   *
+   * Gates on run completion the same way `getResponse()` does, so totals are
+   * final whether you await it directly, after `getResponse()`, or after
+   * consuming any of the streaming getters. On a run that paused (approval /
+   * HITL) or failed, it returns the totals accrued so far — `modelCalls: 0`
+   * with zeroed tokens when no model call ever completed.
+   *
+   * Unlike `getResponse()`, this never rejects: a failed run still consumed
+   * tokens, and cost accounting typically runs in a `finally`/`catch` where a
+   * second throw would mask the run's original error. Await the run itself
+   * (e.g. `getResponse()`) if you need to observe the failure.
+   *
+   * `cost` is present only when the server reported cost accounting for at
+   * least one call; a `0` would be indistinguishable from "free".
+   *
+   * For per-call granularity use the `PostModelCall` hook (one emit per model
+   * call, with `turnType`/`turnNumber`) or `getFullResponsesStream()`, whose
+   * `response.completed` events carry each round's own usage block.
+   */
+  async getUsage(): Promise<SessionUsageTotals> {
+    try {
+      await this.initStreamGuarded({
+        requireStream: false,
+      });
+      if (!this.isResumingFromApproval) {
+        await this.executeToolsIfNeeded();
+      }
+    } catch {
+      // Intentionally swallowed — see the "never rejects" note above. The
+      // aggregate below still reports whatever calls completed before the
+      // failure.
+    }
+    return this.snapshotSessionUsage();
   }
 }

--- a/packages/agent/src/lib/model-result.ts
+++ b/packages/agent/src/lib/model-result.ts
@@ -39,6 +39,7 @@ import {
   buildResponsesMessageStream,
   buildToolCallStream,
   consumeStreamForCompletion,
+  extractCompletionFromBuffer,
   extractReasoningDeltas,
   extractResponsesMessageFromResponse,
   extractTextDeltas,
@@ -1963,9 +1964,10 @@ export class ModelResult<
         if (this.finalResponse) {
           await this.emitPendingModelCallOnce(this.finalResponse);
         } else if (this.reusableStream?.isComplete) {
-          await this.emitPendingModelCallOnce(
-            await consumeStreamForCompletion(this.reusableStream),
-          );
+          // Sync backward scan of the retained buffer — not a consumer
+          // replay, which would cost one microtask hop per buffered event
+          // on every hook-less streaming teardown.
+          await this.emitPendingModelCallOnce(extractCompletionFromBuffer(this.reusableStream));
         }
       }
     } catch (telemetryError) {
@@ -4213,6 +4215,10 @@ export class ModelResult<
    * Get the complete response object including usage information.
    * This will consume the stream until completion and execute any tools.
    * Returns the full OpenResponsesResult with usage data (inputTokens, outputTokens, cachedTokens, etc.)
+   *
+   * Note: in a multi-round tool loop this is the **final** round's response
+   * only — its `usage` block covers that one generation, not the run. For
+   * aggregate totals across every model call, use `getUsage()`.
    */
   async getResponse(): Promise<models.OpenResponsesResult> {
     await this.executeToolsIfNeeded();
@@ -4916,9 +4922,13 @@ export class ModelResult<
    *
    * Gates on run completion the same way `getResponse()` does, so totals are
    * final whether you await it directly, after `getResponse()`, or after
-   * consuming any of the streaming getters. On a run that paused (approval /
-   * HITL) or failed, it returns the totals accrued so far — `modelCalls: 0`
-   * with zeroed tokens when no model call ever completed.
+   * consuming any of the streaming getters — except on an approval-resumed
+   * run, where reading usage never advances the tool loop: the resume
+   * request's own generation is awaited and counted, but no further rounds
+   * are driven, so totals can be mid-run. Await `getResponse()`/`getText()`
+   * first for final totals there. On a run that paused (approval / HITL) or
+   * failed, it returns the totals accrued so far — `modelCalls: 0` with
+   * zeroed tokens when no model call ever completed.
    *
    * Unlike `getResponse()`, this never rejects: a failed run still consumed
    * tokens, and cost accounting typically runs in a `finally`/`catch` where a
@@ -4939,11 +4949,20 @@ export class ModelResult<
       });
       if (!this.isResumingFromApproval) {
         await this.executeToolsIfNeeded();
+      } else if (this.pendingModelCall && this.reusableStream) {
+        // The resume dispatch returned a live event stream whose telemetry
+        // is still parked (the non-streaming branch folds usage in
+        // immediately — see continueWithUnsentResults). Consuming the
+        // reusable stream is a passive observation: it buffers events
+        // without executing tools or mutating conversation state, so the
+        // resume generation is counted without advancing the loop.
+        await this.emitPendingModelCallOnce(await consumeStreamForCompletion(this.reusableStream));
       }
-    } catch {
+    } catch (error) {
       // Intentionally swallowed — see the "never rejects" note above. The
       // aggregate below still reports whatever calls completed before the
-      // failure.
+      // failure; the warn leaves a diagnostic thread for the swallowed cause.
+      console.warn('[getUsage] run failed; reporting totals accrued so far:', error);
     }
     return this.snapshotSessionUsage();
   }

--- a/packages/agent/src/lib/model-result.ts
+++ b/packages/agent/src/lib/model-result.ts
@@ -48,6 +48,7 @@ import {
   extractToolDeltas,
   itemsStreamHandlers,
   streamTerminationEvents,
+  tryExtractCompletionFromBuffer,
 } from './stream-transformers.js';
 import {
   hasTypeProperty,
@@ -1968,6 +1969,19 @@ export class ModelResult<
           // replay, which would cost one microtask hop per buffered event
           // on every hook-less streaming teardown.
           await this.emitPendingModelCallOnce(extractCompletionFromBuffer(this.reusableStream));
+        } else if (this.reusableStream) {
+          // Consumers stop at the terminal event (streamTerminationEvents),
+          // usually before the pump reads the source close that flips
+          // `isComplete` — with a real network stream the close frame
+          // arrives after `response.completed`. The terminal event is
+          // already buffered in that window, so recover it rather than
+          // dropping the parked telemetry. Stays silent (no emit, no
+          // throw) when nothing terminal was buffered — e.g. an errored
+          // mid-flight stream, where no materialized response exists.
+          const buffered = tryExtractCompletionFromBuffer(this.reusableStream);
+          if (buffered) {
+            await this.emitPendingModelCallOnce(buffered);
+          }
         }
       }
     } catch (telemetryError) {

--- a/packages/agent/src/lib/reusable-stream.ts
+++ b/packages/agent/src/lib/reusable-stream.ts
@@ -29,6 +29,24 @@ export class ReusableReadableStream<T> {
   }
 
   /**
+   * Synchronously scan the retained buffer from the end, returning the
+   * last item matching `predicate`. Sees only what has been buffered so
+   * far — call once `isComplete` to cover the whole stream. Unlike a
+   * consumer replay, this costs no per-item microtask hop, so teardown
+   * paths can locate the completion event without re-walking a large
+   * buffer asynchronously.
+   */
+  findLastBuffered(predicate: (item: T) => boolean): T | undefined {
+    for (let i = this.buffer.length - 1; i >= 0; i--) {
+      const item = this.buffer[i]!;
+      if (predicate(item)) {
+        return item;
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Create a new consumer that can independently iterate over the stream.
    * Multiple consumers can be created and will all receive the same data.
    */

--- a/packages/agent/src/lib/stream-transformers.ts
+++ b/packages/agent/src/lib/stream-transformers.ts
@@ -630,6 +630,30 @@ export async function* buildMessageStream(
 }
 
 /**
+ * Backward scan of a `ReusableReadableStream`'s retained buffer for the
+ * last terminal event. Shared by the two extractors below.
+ */
+function findBufferedTerminalEvent(
+  stream: ReusableReadableStream<models.StreamEvents>,
+):
+  | models.StreamEventsResponseCompleted
+  | models.StreamEventsResponseFailed
+  | models.StreamEventsResponseIncomplete
+  | undefined {
+  return stream.findLastBuffered(
+    (event) =>
+      'type' in event &&
+      (isResponseCompletedEvent(event) ||
+        isResponseFailedEvent(event) ||
+        isResponseIncompleteEvent(event)),
+  ) as
+    | models.StreamEventsResponseCompleted
+    | models.StreamEventsResponseFailed
+    | models.StreamEventsResponseIncomplete
+    | undefined;
+}
+
+/**
  * Synchronous counterpart to `consumeStreamForCompletion` for streams that
  * have already fully buffered (`isComplete`): scan the retained buffer
  * backwards for the terminal event instead of replaying every event through
@@ -640,13 +664,7 @@ export async function* buildMessageStream(
 export function extractCompletionFromBuffer(
   stream: ReusableReadableStream<models.StreamEvents>,
 ): models.OpenResponsesResult {
-  const terminal = stream.findLastBuffered(
-    (event) =>
-      'type' in event &&
-      (isResponseCompletedEvent(event) ||
-        isResponseFailedEvent(event) ||
-        isResponseIncompleteEvent(event)),
-  );
+  const terminal = findBufferedTerminalEvent(stream);
 
   if (terminal && isResponseFailedEvent(terminal)) {
     throw new Error(`Response failed: ${JSON.stringify(terminal.response.error)}`);
@@ -655,6 +673,26 @@ export function extractCompletionFromBuffer(
     return terminal.response;
   }
   throw new Error('Stream ended without completion event');
+}
+
+/**
+ * Non-throwing variant of `extractCompletionFromBuffer` for streams that may
+ * still be mid-flight: returns the buffered completed/incomplete response
+ * when the terminal event has already been buffered, `undefined` otherwise
+ * (no terminal event yet, or the response failed). Consumers stop at the
+ * terminal event itself (`streamTerminationEvents`), typically before the
+ * pump has read the source close that flips `isComplete` — this lets
+ * teardown paths recover the completion in that window without waiting on
+ * the close frame.
+ */
+export function tryExtractCompletionFromBuffer(
+  stream: ReusableReadableStream<models.StreamEvents>,
+): models.OpenResponsesResult | undefined {
+  const terminal = findBufferedTerminalEvent(stream);
+  if (terminal && (isResponseCompletedEvent(terminal) || isResponseIncompleteEvent(terminal))) {
+    return terminal.response;
+  }
+  return undefined;
 }
 
 /**

--- a/packages/agent/src/lib/stream-transformers.ts
+++ b/packages/agent/src/lib/stream-transformers.ts
@@ -630,6 +630,34 @@ export async function* buildMessageStream(
 }
 
 /**
+ * Synchronous counterpart to `consumeStreamForCompletion` for streams that
+ * have already fully buffered (`isComplete`): scan the retained buffer
+ * backwards for the terminal event instead of replaying every event through
+ * a fresh consumer (one async microtask hop per event). Same contract —
+ * returns the completed/incomplete response, throws on a failed response or
+ * a buffer with no terminal event.
+ */
+export function extractCompletionFromBuffer(
+  stream: ReusableReadableStream<models.StreamEvents>,
+): models.OpenResponsesResult {
+  const terminal = stream.findLastBuffered(
+    (event) =>
+      'type' in event &&
+      (isResponseCompletedEvent(event) ||
+        isResponseFailedEvent(event) ||
+        isResponseIncompleteEvent(event)),
+  );
+
+  if (terminal && isResponseFailedEvent(terminal)) {
+    throw new Error(`Response failed: ${JSON.stringify(terminal.response.error)}`);
+  }
+  if (terminal && (isResponseCompletedEvent(terminal) || isResponseIncompleteEvent(terminal))) {
+    return terminal.response;
+  }
+  throw new Error('Stream ended without completion event');
+}
+
+/**
  * Consume stream until completion and return the complete response
  */
 export async function consumeStreamForCompletion(

--- a/packages/agent/tests/unit/get-usage.test.ts
+++ b/packages/agent/tests/unit/get-usage.test.ts
@@ -11,6 +11,8 @@
  * - the streaming path: consume getItemsStream() fully, then getUsage()
  * - agreement with the SessionEnd.totalUsage hook payload
  * - usage-less responses still counted in modelCalls, cost omitted
+ * - a run paused at `awaiting_approval` reports only its pre-pause calls,
+ *   including on the approval-resume path that skips executeToolsIfNeeded
  */
 import type * as models from '@openrouter/sdk/models';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -26,6 +28,8 @@ import type { OpenRouterCore } from '@openrouter/sdk/core';
 import { callModel } from '../../src/inner-loop/call-model.js';
 import { HooksManager } from '../../src/lib/hooks-manager.js';
 import type { SessionEndPayload } from '../../src/lib/hooks-types.js';
+import { tool } from '../../src/lib/tool.js';
+import type { ConversationState, StateAccessor, Tool } from '../../src/lib/tool-types.js';
 import { ToolType } from '../../src/lib/tool-types.js';
 
 afterEach(() => {
@@ -73,7 +77,17 @@ function textResponse(id = 'resp_text', usage?: models.Usage | null): models.Ope
   } as unknown as models.OpenResponsesResult;
 }
 
-function toolCallResponse(id = 'resp_tool', usage?: models.Usage): models.OpenResponsesResult {
+function toolCallResponse(
+  id = 'resp_tool',
+  usage?: models.Usage,
+  call: {
+    name: string;
+    arguments: string;
+  } = {
+    name: 'echo',
+    arguments: '{}',
+  },
+): models.OpenResponsesResult {
   return {
     id,
     model: 'test-model-v1',
@@ -82,8 +96,8 @@ function toolCallResponse(id = 'resp_tool', usage?: models.Usage): models.OpenRe
         type: 'function_call',
         id: `out_${id}`,
         callId: `call_${id}`,
-        name: 'echo',
-        arguments: '{}',
+        name: call.name,
+        arguments: call.arguments,
         status: 'completed',
       },
     ],
@@ -105,6 +119,44 @@ function makeEchoTool() {
     },
   };
 }
+
+/** In-memory StateAccessor so an approval pause can be resumed. */
+function makeStateAccessor(): StateAccessor<readonly Tool[]> & {
+  getLatest: () => ConversationState<readonly Tool[]> | null;
+} {
+  let state: ConversationState<readonly Tool[]> | null = null;
+  return {
+    load: async () => state,
+    save: async (s) => {
+      state = s;
+    },
+    getLatest: () => state,
+  };
+}
+
+/** A tool whose every call pauses the run for human approval. */
+const approvalTool = tool({
+  name: 'risky',
+  description: 'Does something that needs a human to sign off.',
+  inputSchema: z.object({
+    target: z.string(),
+  }),
+  outputSchema: z.object({
+    done: z.boolean(),
+  }),
+  requireApproval: true,
+  execute: async () => ({
+    done: true,
+  }),
+});
+
+/** A scripted `function_call` naming the approval-gated tool above. */
+const riskyCall = {
+  name: 'risky',
+  arguments: JSON.stringify({
+    target: 'prod',
+  }),
+};
 
 const client = {} as unknown as OpenRouterCore;
 
@@ -342,5 +394,198 @@ describe('ModelResult.getUsage()', () => {
       totalTokens: 0,
     });
     expect(usage.cost).toBeUndefined();
+  });
+
+  describe('paused at awaiting_approval', () => {
+    it('reports only the model calls that completed before the pause', async () => {
+      // One response: the model calls the approval-gated tool. The tool never
+      // executes and no follow-up request is made — the run parks awaiting a
+      // human decision, so exactly one model call has completed.
+      mockBetaResponsesSend.mockResolvedValueOnce({
+        ok: true,
+        value: toolCallResponse('r1', undefined, riskyCall),
+      });
+
+      const accessor = makeStateAccessor();
+      const result = callModel(client, {
+        model: 'test-model',
+        input: 'do the risky thing',
+        tools: [
+          approvalTool,
+        ] as const,
+        state: accessor,
+      });
+
+      // Drives the loop up to the approval gate (does not throw on a pause).
+      await result.getPendingToolCalls();
+
+      const paused = accessor.getLatest();
+      expect(paused?.status).toBe('awaiting_approval');
+      expect(mockBetaResponsesSend).toHaveBeenCalledTimes(1);
+
+      // Totals reflect the single pre-pause generation, not a zeroed or
+      // speculative aggregate.
+      expect(await result.getUsage()).toEqual({
+        modelCalls: 1,
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+        cachedTokens: 25,
+        reasoningTokens: 10,
+        cost: 0.002,
+      });
+    });
+
+    it('is idempotent while paused and drives no further model requests', async () => {
+      mockBetaResponsesSend.mockResolvedValueOnce({
+        ok: true,
+        value: toolCallResponse('r1', undefined, riskyCall),
+      });
+
+      const accessor = makeStateAccessor();
+      const result = callModel(client, {
+        model: 'test-model',
+        input: 'do the risky thing',
+        tools: [
+          approvalTool,
+        ] as const,
+        state: accessor,
+      });
+      await result.getPendingToolCalls();
+      expect(accessor.getLatest()?.status).toBe('awaiting_approval');
+
+      // Repeated reads of a paused run must not re-drive the loop, dispatch a
+      // request, or double-count the pre-pause generation. A further scripted
+      // response is queued precisely so an accidental dispatch would show up
+      // both as a call count bump and as inflated totals.
+      mockBetaResponsesSend.mockResolvedValueOnce({
+        ok: true,
+        value: textResponse('should-not-be-consumed'),
+      });
+
+      const first = await result.getUsage();
+      expect(first.modelCalls).toBe(1);
+      expect(await result.getUsage()).toEqual(first);
+      expect(mockBetaResponsesSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('scopes totals per ModelResult across an approval resume', async () => {
+      // Run 1: model calls risky(...) → parks at the approval gate.
+      mockBetaResponsesSend.mockResolvedValueOnce({
+        ok: true,
+        value: toolCallResponse('r1', undefined, riskyCall),
+      });
+
+      const accessor = makeStateAccessor();
+      const first = callModel(client, {
+        model: 'test-model',
+        input: 'do the risky thing',
+        tools: [
+          approvalTool,
+        ] as const,
+        state: accessor,
+      });
+      await first.getPendingToolCalls();
+
+      const pausedCallId = accessor.getLatest()?.pendingToolCalls?.[0]?.id;
+      expect(pausedCallId).toBeDefined();
+
+      // Resume: approving the call executes the tool and the unsent-results
+      // request lands one further generation (r2). This resumed ModelResult
+      // carries `isResumingFromApproval`, so getUsage() skips
+      // executeToolsIfNeeded() and reports straight from the aggregate.
+      mockBetaResponsesSend.mockResolvedValueOnce({
+        ok: true,
+        value: textResponse(
+          'r2',
+          usageBlock({
+            inputTokens: 200,
+            outputTokens: 100,
+            totalTokens: 300,
+            cost: 0.003,
+          }),
+        ),
+      });
+
+      const resumed = callModel(client, {
+        model: 'test-model',
+        input: undefined as unknown as string,
+        tools: [
+          approvalTool,
+        ] as const,
+        state: accessor,
+        approveToolCalls: [
+          pausedCallId as string,
+        ],
+      });
+      await resumed.getPendingToolCalls();
+
+      // The aggregate is per-ModelResult, not per-conversation: the resumed
+      // run reports only its OWN generation (r2). Run 1's r1 stays on `first`,
+      // so a caller summing across resumes adds them rather than
+      // double-counting a shared running total.
+      expect(await resumed.getUsage()).toMatchObject({
+        modelCalls: 1,
+        inputTokens: 200,
+        outputTokens: 100,
+        totalTokens: 300,
+        cost: 0.003,
+      });
+      expect(await first.getUsage()).toMatchObject({
+        modelCalls: 1,
+        inputTokens: 100,
+        totalTokens: 150,
+        cost: 0.002,
+      });
+    });
+
+    it('does not advance an approval-resumed run when read before the loop', async () => {
+      // Pins the `isResumingFromApproval` guard specifically. Reading usage is
+      // an observation, so on a resumed run it must NOT stand in for driving
+      // the loop: without the guard this call runs executeToolsIfNeeded() and
+      // settles the conversation to 'complete' as a side effect of asking a
+      // question. Totals alone can't catch that — the resume's generation is
+      // dispatched during initStream either way — so assert on run status.
+      mockBetaResponsesSend.mockResolvedValueOnce({
+        ok: true,
+        value: toolCallResponse('r1', undefined, riskyCall),
+      });
+
+      const accessor = makeStateAccessor();
+      const first = callModel(client, {
+        model: 'test-model',
+        input: 'do the risky thing',
+        tools: [
+          approvalTool,
+        ] as const,
+        state: accessor,
+      });
+      await first.getPendingToolCalls();
+      const pausedCallId = accessor.getLatest()?.pendingToolCalls?.[0]?.id;
+
+      mockBetaResponsesSend.mockResolvedValueOnce({
+        ok: true,
+        value: textResponse('r2'),
+      });
+
+      const resumed = callModel(client, {
+        model: 'test-model',
+        input: undefined as unknown as string,
+        tools: [
+          approvalTool,
+        ] as const,
+        state: accessor,
+        approveToolCalls: [
+          pausedCallId as string,
+        ],
+      });
+
+      // getUsage() is the FIRST call on the resumed run — nothing has driven
+      // the loop yet.
+      expect(await resumed.getUsage()).toMatchObject({
+        modelCalls: 1,
+      });
+      expect(accessor.getLatest()?.status).toBe('in_progress');
+    });
   });
 });

--- a/packages/agent/tests/unit/get-usage.test.ts
+++ b/packages/agent/tests/unit/get-usage.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Tests for the pull-based usage accessor on ModelResult (`getUsage()`).
+ *
+ * Issue #10: with `getItemsStream()` and multi-round tool-calling runs,
+ * per-round usage is unreachable — `getResponse()` returns only the final
+ * round's response, so the `tool_calls` generations' tokens are lost.
+ *
+ * Covers:
+ * - totals summed across every round of a multi-round tool loop
+ * - the accessor works WITHOUT hooks configured (pull-based, not hook-driven)
+ * - the streaming path: consume getItemsStream() fully, then getUsage()
+ * - agreement with the SessionEnd.totalUsage hook payload
+ * - usage-less responses still counted in modelCalls, cost omitted
+ */
+import type * as models from '@openrouter/sdk/models';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+const mockBetaResponsesSend = vi.hoisted(() => vi.fn());
+
+vi.mock('@openrouter/sdk/funcs/betaResponsesSend', () => ({
+  betaResponsesSend: mockBetaResponsesSend,
+}));
+
+import type { OpenRouterCore } from '@openrouter/sdk/core';
+import { callModel } from '../../src/inner-loop/call-model.js';
+import { HooksManager } from '../../src/lib/hooks-manager.js';
+import type { SessionEndPayload } from '../../src/lib/hooks-types.js';
+import { ToolType } from '../../src/lib/tool-types.js';
+
+afterEach(() => {
+  mockBetaResponsesSend.mockReset();
+  vi.restoreAllMocks();
+});
+
+function usageBlock(overrides?: Partial<models.Usage>): models.Usage {
+  return {
+    inputTokens: 100,
+    inputTokensDetails: {
+      cachedTokens: 25,
+    },
+    outputTokens: 50,
+    outputTokensDetails: {
+      reasoningTokens: 10,
+    },
+    totalTokens: 150,
+    cost: 0.002,
+    ...overrides,
+  } as models.Usage;
+}
+
+function textResponse(id = 'resp_text', usage?: models.Usage | null): models.OpenResponsesResult {
+  return {
+    id,
+    model: 'test-model-v1',
+    output: [
+      {
+        type: 'message',
+        id: `msg_${id}`,
+        role: 'assistant',
+        content: [
+          {
+            type: 'output_text',
+            text: 'hello back',
+          },
+        ],
+        status: 'completed',
+      },
+    ],
+    ...(usage !== null && {
+      usage: usage ?? usageBlock(),
+    }),
+  } as unknown as models.OpenResponsesResult;
+}
+
+function toolCallResponse(id = 'resp_tool', usage?: models.Usage): models.OpenResponsesResult {
+  return {
+    id,
+    model: 'test-model-v1',
+    output: [
+      {
+        type: 'function_call',
+        id: `out_${id}`,
+        callId: `call_${id}`,
+        name: 'echo',
+        arguments: '{}',
+        status: 'completed',
+      },
+    ],
+    usage: usage ?? usageBlock(),
+  } as unknown as models.OpenResponsesResult;
+}
+
+function makeEchoTool() {
+  return {
+    type: ToolType.Function,
+    function: {
+      name: 'echo',
+      description: 'echo',
+      inputSchema: z.object({}).loose(),
+      outputSchema: z.unknown(),
+      execute: async () => ({
+        ok: true,
+      }),
+    },
+  };
+}
+
+const client = {} as unknown as OpenRouterCore;
+
+describe('ModelResult.getUsage()', () => {
+  it('sums usage across every round of a multi-round tool loop', async () => {
+    // Round 1: tool_calls generation. Round 2: final stop generation.
+    // getResponse() only exposes round 2 — this is the gap in issue #10.
+    mockBetaResponsesSend
+      .mockResolvedValueOnce({
+        ok: true,
+        value: toolCallResponse('r1'),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: textResponse(
+          'r2',
+          usageBlock({
+            inputTokens: 200,
+            outputTokens: 100,
+            totalTokens: 300,
+            cost: 0.003,
+          }),
+        ),
+      });
+
+    const result = callModel(client, {
+      model: 'test-model',
+      input: 'hi',
+      tools: [
+        makeEchoTool(),
+      ],
+    });
+
+    await result.getResponse();
+    const usage = await result.getUsage();
+
+    expect(usage).toEqual({
+      modelCalls: 2,
+      inputTokens: 300,
+      outputTokens: 150,
+      totalTokens: 450,
+      cachedTokens: 50,
+      reasoningTokens: 20,
+      cost: 0.005,
+    });
+
+    // The gap this closes: the final response alone reports only round 2.
+    const finalResponse = await result.getResponse();
+    expect(finalResponse.usage?.totalTokens).toBe(300);
+  });
+
+  it('awaits run completion when called without awaiting getResponse() first', async () => {
+    mockBetaResponsesSend
+      .mockResolvedValueOnce({
+        ok: true,
+        value: toolCallResponse('r1'),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: textResponse('r2'),
+      });
+
+    const result = callModel(client, {
+      model: 'test-model',
+      input: 'hi',
+      tools: [
+        makeEchoTool(),
+      ],
+    });
+
+    // No prior await — getUsage() must gate on completion itself.
+    const usage = await result.getUsage();
+    expect(usage.modelCalls).toBe(2);
+    expect(usage.totalTokens).toBe(300);
+  });
+
+  it('accumulates with no hooks configured (pull-based, not hook-driven)', async () => {
+    mockBetaResponsesSend.mockResolvedValue({
+      ok: true,
+      value: textResponse('r1'),
+    });
+
+    const result = callModel(client, {
+      model: 'test-model',
+      input: 'hi',
+    });
+    await result.getText();
+
+    expect(await result.getUsage()).toEqual({
+      modelCalls: 1,
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+      cachedTokens: 25,
+      reasoningTokens: 10,
+      cost: 0.002,
+    });
+  });
+
+  it('reports complete totals after consuming getItemsStream() on a tool loop', async () => {
+    mockBetaResponsesSend
+      .mockResolvedValueOnce({
+        ok: true,
+        value: toolCallResponse('r1'),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: textResponse(
+          'r2',
+          usageBlock({
+            inputTokens: 200,
+            outputTokens: 100,
+            totalTokens: 300,
+            cost: 0.003,
+          }),
+        ),
+      });
+
+    const result = callModel(client, {
+      model: 'test-model',
+      input: 'hi',
+      tools: [
+        makeEchoTool(),
+      ],
+    });
+
+    for await (const _item of result.getItemsStream()) {
+      // drain
+    }
+
+    expect(await result.getUsage()).toEqual({
+      modelCalls: 2,
+      inputTokens: 300,
+      outputTokens: 150,
+      totalTokens: 450,
+      cachedTokens: 50,
+      reasoningTokens: 20,
+      cost: 0.005,
+    });
+  });
+
+  it('reports complete totals after consuming the no-tools getItemsStream()', async () => {
+    mockBetaResponsesSend.mockResolvedValue({
+      ok: true,
+      value: textResponse('r1'),
+    });
+
+    const result = callModel(client, {
+      model: 'test-model',
+      input: 'hi',
+    });
+
+    for await (const _item of result.getItemsStream()) {
+      // drain
+    }
+
+    expect(await result.getUsage()).toMatchObject({
+      modelCalls: 1,
+      totalTokens: 150,
+    });
+  });
+
+  it('agrees with the SessionEnd.totalUsage hook payload', async () => {
+    mockBetaResponsesSend
+      .mockResolvedValueOnce({
+        ok: true,
+        value: toolCallResponse('r1'),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: textResponse('r2'),
+      });
+
+    const hooks = new HooksManager();
+    const ends: SessionEndPayload[] = [];
+    hooks.on('SessionEnd', {
+      handler: (payload) => {
+        ends.push(payload);
+      },
+    });
+
+    const result = callModel(client, {
+      model: 'test-model',
+      input: 'hi',
+      tools: [
+        makeEchoTool(),
+      ],
+      hooks,
+    });
+    await result.getText();
+
+    expect(ends).toHaveLength(1);
+    expect(await result.getUsage()).toEqual(ends[0]?.totalUsage);
+  });
+
+  it('counts usage-less responses in modelCalls and omits cost', async () => {
+    mockBetaResponsesSend.mockResolvedValue({
+      ok: true,
+      value: textResponse('r1', null),
+    });
+
+    const result = callModel(client, {
+      model: 'test-model',
+      input: 'hi',
+    });
+    await result.getText();
+
+    const usage = await result.getUsage();
+    expect(usage).toMatchObject({
+      modelCalls: 1,
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      cachedTokens: 0,
+      reasoningTokens: 0,
+    });
+    expect(usage.cost).toBeUndefined();
+  });
+
+  it('returns zeroed totals when no model call completed', async () => {
+    mockBetaResponsesSend.mockResolvedValue({
+      ok: false,
+      error: new Error('api down'),
+    });
+
+    const result = callModel(client, {
+      model: 'test-model',
+      input: 'hi',
+    });
+    await expect(result.getText()).rejects.toThrow('api down');
+
+    const usage = await result.getUsage();
+    expect(usage).toMatchObject({
+      modelCalls: 0,
+      totalTokens: 0,
+    });
+    expect(usage.cost).toBeUndefined();
+  });
+});

--- a/packages/agent/tests/unit/get-usage.test.ts
+++ b/packages/agent/tests/unit/get-usage.test.ts
@@ -13,6 +13,9 @@
  * - usage-less responses still counted in modelCalls, cost omitted
  * - a run paused at `awaiting_approval` reports only its pre-pause calls,
  *   including on the approval-resume path that skips executeToolsIfNeeded
+ * - an approval resume whose response is a real event stream still gets its
+ *   resume generation counted by a bare getUsage(), without loop side effects
+ * - a totally failed run warns with the swallowed cause (never-throw ≠ silent)
  */
 import type * as models from '@openrouter/sdk/models';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -376,11 +379,12 @@ describe('ModelResult.getUsage()', () => {
     expect(usage.cost).toBeUndefined();
   });
 
-  it('returns zeroed totals when no model call completed', async () => {
+  it('returns zeroed totals when no model call completed, warning with the swallowed cause', async () => {
     mockBetaResponsesSend.mockResolvedValue({
       ok: false,
       error: new Error('api down'),
     });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     const result = callModel(client, {
       model: 'test-model',
@@ -394,6 +398,16 @@ describe('ModelResult.getUsage()', () => {
       totalTokens: 0,
     });
     expect(usage.cost).toBeUndefined();
+
+    // Never-throws must not mean silent: the caller who only ever awaits
+    // getUsage() (e.g. a cost-accounting sidecar) needs a diagnostic to
+    // distinguish "the API was down" from "the run was genuinely free".
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[getUsage] run failed; reporting totals accrued so far:',
+      expect.objectContaining({
+        message: 'api down',
+      }),
+    );
   });
 
   describe('paused at awaiting_approval', () => {
@@ -585,6 +599,76 @@ describe('ModelResult.getUsage()', () => {
       expect(await resumed.getUsage()).toMatchObject({
         modelCalls: 1,
       });
+      expect(accessor.getLatest()?.status).toBe('in_progress');
+    });
+
+    it('counts a STREAMING resume generation without advancing the loop', async () => {
+      // The resume dispatch may return a real event stream instead of a
+      // non-streaming body. Its telemetry stays parked until something
+      // consumes the stream — a bare getUsage() must do that consumption
+      // itself (a passive buffer read) rather than under-report the resume
+      // request's tokens, while still not driving the tool loop.
+      mockBetaResponsesSend.mockResolvedValueOnce({
+        ok: true,
+        value: toolCallResponse('r1', undefined, riskyCall),
+      });
+
+      const accessor = makeStateAccessor();
+      const first = callModel(client, {
+        model: 'test-model',
+        input: 'do the risky thing',
+        tools: [
+          approvalTool,
+        ] as const,
+        state: accessor,
+      });
+      await first.getPendingToolCalls();
+      const pausedCallId = accessor.getLatest()?.pendingToolCalls?.[0]?.id;
+
+      const resumeResponse = textResponse(
+        'r2_streamed',
+        usageBlock({
+          inputTokens: 200,
+          outputTokens: 100,
+          totalTokens: 300,
+          cost: 0.003,
+        }),
+      );
+      mockBetaResponsesSend.mockResolvedValueOnce({
+        ok: true,
+        value: new ReadableStream({
+          start(controller) {
+            controller.enqueue({
+              type: 'response.completed',
+              response: resumeResponse,
+              sequenceNumber: 0,
+            });
+            controller.close();
+          },
+        }),
+      });
+
+      const resumed = callModel(client, {
+        model: 'test-model',
+        input: undefined as unknown as string,
+        tools: [
+          approvalTool,
+        ] as const,
+        state: accessor,
+        approveToolCalls: [
+          pausedCallId as string,
+        ],
+      });
+
+      // Bare read, nothing else has consumed the resume stream.
+      expect(await resumed.getUsage()).toMatchObject({
+        modelCalls: 1,
+        inputTokens: 200,
+        outputTokens: 100,
+        totalTokens: 300,
+        cost: 0.003,
+      });
+      // Observation only: the run has not been settled as a side effect.
       expect(accessor.getLatest()?.status).toBe('in_progress');
     });
   });

--- a/packages/agent/tests/unit/hooks-post-model-call.test.ts
+++ b/packages/agent/tests/unit/hooks-post-model-call.test.ts
@@ -337,6 +337,51 @@ describe('PostModelCall hook', () => {
     });
   });
 
+  it('emits when the source close arrives after the terminal event (isComplete still false)', async () => {
+    // Real network streams deliver the close frame after `response.completed`.
+    // Item consumers stop at the terminal event, so teardown typically runs
+    // before the pump has observed the close that flips `isComplete` — the
+    // parked telemetry must be recovered from the buffered terminal event,
+    // not dropped. Modeled here with a source that never closes: the
+    // completed event is buffered, `isComplete` stays false forever.
+    const streamed = textResponse('r_late_close');
+    const readable = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          type: 'response.completed',
+          response: streamed,
+          sequenceNumber: 0,
+        });
+        // no controller.close(): the pump keeps awaiting the source.
+      },
+    });
+    mockBetaResponsesSend.mockResolvedValue({
+      ok: true,
+      value: readable,
+    });
+
+    const { hooks, calls, ends } = collectHooks();
+    const result = callModel(client, {
+      model: 'test-model',
+      input: 'hi',
+      hooks,
+    });
+    for await (const _item of result.getItemsStream()) {
+      // drain — terminates at the buffered response.completed event
+    }
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      responseId: 'r_late_close',
+      turnType: 'initial',
+    });
+    expect(ends).toHaveLength(1);
+    expect(ends[0]?.totalUsage).toMatchObject({
+      modelCalls: 1,
+      totalTokens: 150,
+    });
+  });
+
   it('still emits SessionEnd and drains when teardown telemetry cannot materialize', async () => {
     // A stream that ends without a completion event (deltas only, then close)
     // makes the parked-telemetry materialization in teardown throw


### PR DESCRIPTION
Closes #10

## The gap

Reported against `getItemsStream()` with a multi-round tool-calling run: "I only get the last generation with `stop`. I don't get the generations with `tool_calls`."

Two things compound:

- **`getResponse()` returns only the final round.** `finalResponse` is the last response the loop materialized, so `response.usage` accounts for the closing `stop` generation alone. Every intermediate `tool_calls` generation's tokens are unreachable through it.
- **`getItemsStream()` carries output items only.** It yields `message` / `function_call` / `reasoning` / `function_call_output` items and never surfaces the `response.completed` events that hold each round's usage block. So a caller who consumes items and then calls `getResponse()` gets the final round twice over, and nothing else.

Net effect: no pull-based way to answer "what did this run cost?"

## What already existed

- **`PostModelCall` hook** — fires once per completed model response with `turnType` / `turnNumber` / `usage`. Correct per-call granularity, but push-based: you must register a hook before the run.
- **`SessionEnd.totalUsage`** — the aggregate, already computed and already the right shape (`SessionUsageTotals`). Also push-based, and only emitted at teardown.
- **`getFullResponsesStream()`** — does surface each round's `response.completed`, so per-round usage is technically reachable, but only by consuming the raw event stream instead of the items stream.
- **`allToolExecutionRounds`** — retains each round's full `response`.

The aggregate the issue wants was therefore already being computed on every run and simply had no public reader.

## What this adds

`ModelResult.getUsage(): Promise<SessionUsageTotals>` — reuses the existing hook type/schema rather than inventing a shape, so `getUsage()` and `SessionEnd.totalUsage` are the same numbers by construction (both read one new private `snapshotSessionUsage()` helper).

```ts
const result = callModel(client, { model, input, tools });

for await (const item of result.getItemsStream()) {
  render(item);
}

const usage = await result.getUsage();
console.log(usage.modelCalls, usage.totalTokens, usage.cost);
```

Covers the initial request, each tool-round follow-up, the empty-final retry, the `allowFinalResponse` final turn, and approval-resume requests.

### Two supporting fixes

The aggregate was previously only correct when hooks were configured — accumulation ran as a side effect of hook emission:

- `emitPostModelCall` now folds usage in **before** the `hooksManager` short-circuit; only the emit stays gated.
- `finishHooksSessionForStream` now materializes the parked model-call telemetry **before** its `hooksManager` guard. This is the only site that folds the no-tools streaming response into the aggregate, so without this a hook-less `getItemsStream()` / `getTextStream()` run reported `modelCalls: 0`.

Neither changes hook-facing behavior (a test asserts `getUsage()` equals the `SessionEnd.totalUsage` payload); all 651 existing agent tests pass unchanged.

## Judgment calls

- **Awaits completion, like `getResponse()`.** Gates on `initStreamGuarded()` + `executeToolsIfNeeded()`, mirroring `getDoomLoopVerdict()`. So the totals are final whether you await it directly, after `getResponse()`, or after draining any streaming getter.
- **Never rejects.** A failed run still consumed tokens, and cost accounting typically runs in a `finally`/`catch` where a second throw would mask the run's original error. A failed/paused run returns totals accrued so far; `modelCalls: 0` with zeroed tokens when nothing completed. Await the run itself if you need to observe the failure.
- **`cost` stays optional**, matching the hook payload — a summed `0` from cost-less responses would read as "free" rather than "unknown".
- **No per-round accessor (`getRounds()`) in this PR.** It does *not* drop out cleanly: both `allToolExecutionRounds.push` sites store the response that *produced* the tool calls, so the closing `stop` round and the `final` / `retry` turns are never in that array. An accessor over it would silently under-report exactly the rounds the issue is about. Per-round usage is already reachable via the `PostModelCall` hook or `getFullResponsesStream()`'s `response.completed`; a dedicated accessor would want its own per-call ledger and is better as a follow-up.

## Testing

Written red-first — all 8 failed with `result.getUsage is not a function` before implementation, then green. `packages/agent/tests/unit/get-usage.test.ts` covers the multi-round sum (asserting the same run's `getResponse()` still reports only 300 of 450 tokens), the streaming path via a fully-consumed `getItemsStream()` (both tool-loop and no-tools), the no-hooks path, agreement with `SessionEnd.totalUsage`, usage-less responses, and a failed run.

Build, typecheck, lint, and the full suite (754 tests) all green. Changeset included (minor — new public API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)