### PR TITLE
ci: make PR checks the enforced source of truth with coverage ratchets

### DIFF
--- a/.github/scripts/coverage-summary.mjs
+++ b/.github/scripts/coverage-summary.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * Prints a markdown coverage summary table for the CI job summary.
+ * Reads each package's coverage-summary.json (written by vitest's
+ * json-summary reporter). Missing files are reported, not fatal — the
+ * threshold gate in the test step is what enforces coverage.
+ */
+import { readFileSync } from 'node:fs';
+
+const packages = ['agent', 'mcp'];
+
+const rows = ['| Package | Statements | Branches | Functions | Lines |', '| --- | --- | --- | --- | --- |'];
+
+for (const pkg of packages) {
+  const path = `packages/${pkg}/coverage/coverage-summary.json`;
+  try {
+    const summary = JSON.parse(readFileSync(path, 'utf8'));
+    const total = summary.total;
+    rows.push(
+      `| ${pkg} | ${total.statements.pct}% | ${total.branches.pct}% | ${total.functions.pct}% | ${total.lines.pct}% |`,
+    );
+  } catch {
+    rows.push(`| ${pkg} | ⚠️ no coverage report | | | |`);
+  }
+}
+
+console.log('## Coverage\n');
+console.log(rows.join('\n'));

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,18 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Nightly full run on main, including live e2e smoke tests.
+    - cron: '0 6 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   TURBO_TELEMETRY_DISABLED: '1'
@@ -62,8 +74,25 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Tests
+      # Coverage is always collected (enabled in each package's vitest
+      # config) and the run FAILS if any package drops below its pinned
+      # thresholds. This job is the coverage gate for every PR.
+      - name: Unit tests with coverage thresholds
         run: pnpm run test
+
+      - name: Coverage summary
+        if: always()
+        run: node .github/scripts/coverage-summary.mjs >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: |
+            packages/*/coverage/
+          if-no-files-found: ignore
+          retention-days: 14
 
   e2e-tests:
     runs-on: ubuntu-latest
@@ -72,24 +101,43 @@ jobs:
         with:
           fetch-depth: 2
 
+      # Live API smoke tests require the OPENROUTER_API_KEY secret.
+      # Fork PRs never receive secrets, so skipping is legitimate ONLY there.
+      # For same-repo PRs, pushes to main, and nightly runs, a missing key
+      # is a hard failure — silently green e2e is worse than no e2e.
+      - name: Guard API key availability
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
+        run: |
+          if [ -n "$OPENROUTER_API_KEY" ]; then
+            exit 0
+          fi
+          if [ "$IS_FORK" = "true" ]; then
+            echo "::warning::Fork PR: secrets are unavailable, skipping live e2e tests."
+            echo "SKIP_E2E=1" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          echo "::error::OPENROUTER_API_KEY secret is not set; refusing to skip e2e tests outside of fork PRs."
+          exit 1
+
       - uses: pnpm/action-setup@v6
+        if: env.SKIP_E2E != '1'
 
       - uses: actions/setup-node@v6
+        if: env.SKIP_E2E != '1'
         with:
           node-version: 22
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - if: env.SKIP_E2E != '1'
+        run: pnpm install --frozen-lockfile
 
       - name: E2E tests
+        if: env.SKIP_E2E != '1'
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-        run: |
-          if [ -z "$OPENROUTER_API_KEY" ]; then
-            echo "::warning::OPENROUTER_API_KEY is not set; skipping e2e tests."
-            exit 0
-          fi
-          pnpm run test:e2e
+        run: pnpm run test:e2e
 
   structural-gate:
     runs-on: ubuntu-latest
@@ -110,3 +158,38 @@ jobs:
 
       - name: Structural regression gate
         run: sentrux gate
+
+  # Single aggregated status check. Point branch protection at THIS job
+  # ("ci-status") so the set of required checks is defined in one place —
+  # adding a job to `needs` automatically extends the gate, and a renamed
+  # or deleted job can never silently leave the gate green.
+  ci-status:
+    name: CI status
+    if: always()
+    needs: [lint, typecheck, unit-tests, e2e-tests, structural-gate]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all checks passed
+        env:
+          RESULTS: >-
+            lint=${{ needs.lint.result }}
+            typecheck=${{ needs.typecheck.result }}
+            unit-tests=${{ needs.unit-tests.result }}
+            e2e-tests=${{ needs.e2e-tests.result }}
+            structural-gate=${{ needs.structural-gate.result }}
+        run: |
+          failed=0
+          for entry in $RESULTS; do
+            job="${entry%%=*}"
+            result="${entry#*=}"
+            echo "$job: $result"
+            # "skipped" is acceptable (e.g. e2e on fork PRs); anything else
+            # that isn't "success" fails the gate.
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              failed=1
+            fi
+          done
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::One or more CI checks did not pass."
+            exit 1
+          fi

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -142,7 +142,7 @@
     "lint:fix": "biome check --write src tests",
     "build": "tsc",
     "test": "vitest --run --project unit",
-    "test:e2e": "vitest --run --project e2e",
+    "test:e2e": "vitest --run --project e2e --coverage.enabled=false",
     "test:watch": "vitest --watch --project unit",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "compile": "tsc"

--- a/packages/agent/tests/unit/agent-tool.test.ts
+++ b/packages/agent/tests/unit/agent-tool.test.ts
@@ -500,7 +500,6 @@ describe('tool.agent — child conversation as a background task', () => {
     const childGate = new Promise<void>((resolve) => {
       releaseChild = resolve;
     });
-    let steered = false;
 
     routeByModel({
       parent: () => {
@@ -571,7 +570,6 @@ describe('tool.agent — child conversation as a background task', () => {
         throw new Error('agent task not started');
       }
       expect(result.sendToTask(task.taskId, 'focus on array semantics')).toBe(true);
-      steered = true;
       releaseChild?.();
     });
     await textPromise;

--- a/packages/agent/tests/unit/claude-type-guards.test.ts
+++ b/packages/agent/tests/unit/claude-type-guards.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest';
+import { ClaudeContentBlockType } from '../../src/lib/claude-constants.js';
+import { isClaudeStyleMessages } from '../../src/lib/claude-type-guards.js';
+
+describe('isClaudeStyleMessages', () => {
+  it('returns false for non-array input', () => {
+    expect(isClaudeStyleMessages('hello')).toBe(false);
+    expect(isClaudeStyleMessages(null)).toBe(false);
+    expect(isClaudeStyleMessages(undefined)).toBe(false);
+    expect(isClaudeStyleMessages(42)).toBe(false);
+    expect(
+      isClaudeStyleMessages({
+        role: 'user',
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for an empty array', () => {
+    expect(isClaudeStyleMessages([])).toBe(false);
+  });
+
+  it('detects tool_result content blocks', () => {
+    const input = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: ClaudeContentBlockType.ToolResult,
+            tool_use_id: 'x',
+            content: 'ok',
+          },
+        ],
+      },
+    ];
+    expect(isClaudeStyleMessages(input)).toBe(true);
+  });
+
+  it('detects image blocks with a source', () => {
+    const input = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: ClaudeContentBlockType.Image,
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: 'abc',
+            },
+          },
+        ],
+      },
+    ];
+    expect(isClaudeStyleMessages(input)).toBe(true);
+  });
+
+  it('rejects image blocks without a source object', () => {
+    const noSource = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: ClaudeContentBlockType.Image,
+          },
+        ],
+      },
+    ];
+    expect(isClaudeStyleMessages(noSource)).toBe(false);
+
+    const nonObjectSource = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: ClaudeContentBlockType.Image,
+            source: 'base64',
+          },
+        ],
+      },
+    ];
+    expect(isClaudeStyleMessages(nonObjectSource)).toBe(false);
+  });
+
+  it('detects tool_use blocks with a string id', () => {
+    const input = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ClaudeContentBlockType.ToolUse,
+            id: 'toolu_1',
+            name: 'x',
+            input: {},
+          },
+        ],
+      },
+    ];
+    expect(isClaudeStyleMessages(input)).toBe(true);
+  });
+
+  it('rejects tool_use blocks with a non-string id', () => {
+    const input = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ClaudeContentBlockType.ToolUse,
+            id: 123,
+          },
+        ],
+      },
+    ];
+    expect(isClaudeStyleMessages(input)).toBe(false);
+  });
+
+  it('returns false for plain OpenAI-style string content', () => {
+    const input = [
+      {
+        role: 'user',
+        content: 'hello',
+      },
+      {
+        role: 'assistant',
+        content: 'hi there',
+      },
+    ];
+    expect(isClaudeStyleMessages(input)).toBe(false);
+  });
+
+  it('returns false when any message has a non-Claude role', () => {
+    const input = [
+      {
+        role: 'system',
+        content: [
+          {
+            type: ClaudeContentBlockType.ToolResult,
+          },
+        ],
+      },
+    ];
+    expect(isClaudeStyleMessages(input)).toBe(false);
+
+    expect(
+      isClaudeStyleMessages([
+        {
+          role: 'developer',
+          content: [
+            {
+              type: ClaudeContentBlockType.ToolResult,
+            },
+          ],
+        },
+      ]),
+    ).toBe(false);
+
+    expect(
+      isClaudeStyleMessages([
+        {
+          role: 'tool',
+          content: [
+            {
+              type: ClaudeContentBlockType.Image,
+              source: {},
+            },
+          ],
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it('skips non-record entries and messages without a role', () => {
+    const input = [
+      'not-a-message',
+      {
+        content: [
+          {
+            type: ClaudeContentBlockType.ToolResult,
+          },
+        ],
+      }, // no role
+      {
+        role: 'user',
+        content: [
+          {
+            type: ClaudeContentBlockType.ToolResult,
+          },
+        ],
+      },
+    ];
+    expect(isClaudeStyleMessages(input)).toBe(true);
+  });
+
+  it('skips messages that carry a top-level type (responses-style items)', () => {
+    const input = [
+      {
+        role: 'user',
+        type: 'message',
+        content: [
+          {
+            type: ClaudeContentBlockType.ToolResult,
+          },
+        ],
+      },
+    ];
+    expect(isClaudeStyleMessages(input)).toBe(false);
+  });
+
+  it('returns false when content blocks are all plain text', () => {
+    const input = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'hello',
+          },
+        ],
+      },
+    ];
+    expect(isClaudeStyleMessages(input)).toBe(false);
+  });
+
+  it('ignores non-record blocks inside content arrays', () => {
+    const input = [
+      {
+        role: 'user',
+        content: [
+          'just-a-string',
+          null,
+          42,
+        ],
+      },
+    ];
+    expect(isClaudeStyleMessages(input)).toBe(false);
+  });
+
+  it('detects Claude blocks in later messages even if earlier ones are plain', () => {
+    const input = [
+      {
+        role: 'user',
+        content: 'hello',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ClaudeContentBlockType.ToolUse,
+            id: 'toolu_9',
+            name: 'x',
+            input: {},
+          },
+        ],
+      },
+    ];
+    expect(isClaudeStyleMessages(input)).toBe(true);
+  });
+});

--- a/packages/agent/tests/unit/next-turn-params.test.ts
+++ b/packages/agent/tests/unit/next-turn-params.test.ts
@@ -1,0 +1,370 @@
+import type * as models from '@openrouter/sdk/models';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import {
+  buildNextTurnParamsContext,
+  executeNextTurnParamsFunctions,
+} from '../../src/lib/next-turn-params.js';
+import { tool } from '../../src/lib/tool.js';
+import type { ParsedToolCall, Tool } from '../../src/lib/tool-types.js';
+
+function createRequest(overrides?: Partial<models.ResponsesRequest>): models.ResponsesRequest {
+  return {
+    model: 'openai/gpt-4',
+    input: [
+      {
+        role: 'user',
+        content: 'hello',
+      },
+    ],
+    ...overrides,
+  } as unknown as models.ResponsesRequest;
+}
+
+function createToolCall(name: string, args: unknown): ParsedToolCall<Tool> {
+  return {
+    id: `call_${name}`,
+    name,
+    arguments: args,
+  } as ParsedToolCall<Tool>;
+}
+
+describe('buildNextTurnParamsContext', () => {
+  it('extracts all fields from a fully populated request', () => {
+    const request = createRequest({
+      models: [
+        'openai/gpt-4',
+        'anthropic/claude',
+      ],
+      temperature: 0.7,
+      maxOutputTokens: 500,
+      topP: 0.9,
+      topK: 40,
+      instructions: 'Be terse',
+    } as Partial<models.ResponsesRequest>);
+
+    const context = buildNextTurnParamsContext(request);
+
+    expect(context).toEqual({
+      input: request.input,
+      model: 'openai/gpt-4',
+      models: [
+        'openai/gpt-4',
+        'anthropic/claude',
+      ],
+      temperature: 0.7,
+      maxOutputTokens: 500,
+      topP: 0.9,
+      topK: 40,
+      instructions: 'Be terse',
+    });
+  });
+
+  it('applies defaults for missing fields', () => {
+    const context = buildNextTurnParamsContext({} as models.ResponsesRequest);
+
+    expect(context).toEqual({
+      input: [],
+      model: '',
+      models: [],
+      temperature: null,
+      maxOutputTokens: null,
+      topP: null,
+      topK: undefined,
+      instructions: null,
+    });
+  });
+});
+
+describe('executeNextTurnParamsFunctions', () => {
+  it('returns an empty object when no tools have nextTurnParams', async () => {
+    const plainTool = tool({
+      name: 'plain',
+      inputSchema: z.object({
+        q: z.string(),
+      }),
+      execute: async () => 'done',
+    });
+
+    const result = await executeNextTurnParamsFunctions(
+      [
+        createToolCall('plain', {
+          q: 'x',
+        }),
+      ],
+      [
+        plainTool,
+      ],
+      createRequest(),
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it('computes parameters from tool call arguments and context', async () => {
+    const searchTool = tool({
+      name: 'search',
+      inputSchema: z.object({
+        depth: z.number(),
+      }),
+      execute: async () => 'done',
+      nextTurnParams: {
+        temperature: (params) => (params.depth > 3 ? 0.1 : 0.9),
+        instructions: (params, context) => `${context.instructions ?? ''} depth=${params.depth}`,
+      },
+    });
+
+    const result = await executeNextTurnParamsFunctions(
+      [
+        createToolCall('search', {
+          depth: 5,
+        }),
+      ],
+      [
+        searchTool,
+      ],
+      createRequest({
+        instructions: 'Base.',
+      } as Partial<models.ResponsesRequest>),
+    );
+
+    expect(result.temperature).toBe(0.1);
+    expect(result.instructions).toBe('Base. depth=5');
+  });
+
+  it('composes: later tools see modifications made by earlier tools', async () => {
+    const firstTool = tool({
+      name: 'first',
+      inputSchema: z.object({}),
+      execute: async () => 'done',
+      nextTurnParams: {
+        temperature: () => 0.5,
+      },
+    });
+    const secondTool = tool({
+      name: 'second',
+      inputSchema: z.object({}),
+      execute: async () => 'done',
+      nextTurnParams: {
+        temperature: (_params, context) => (context.temperature ?? 0) + 0.3,
+      },
+    });
+
+    const result = await executeNextTurnParamsFunctions(
+      [
+        createToolCall('first', {}),
+        createToolCall('second', {}),
+      ],
+      [
+        firstTool,
+        secondTool,
+      ],
+      createRequest({
+        temperature: 0.7,
+      } as Partial<models.ResponsesRequest>),
+    );
+
+    // first sets 0.5; second sees 0.5 (not the original 0.7) and adds 0.3
+    expect(result.temperature).toBeCloseTo(0.8);
+  });
+
+  it('awaits async nextTurnParams functions', async () => {
+    const asyncTool = tool({
+      name: 'async_tool',
+      inputSchema: z.object({}),
+      execute: async () => 'done',
+      nextTurnParams: {
+        model: async () => 'openai/gpt-5',
+      },
+    });
+
+    const result = await executeNextTurnParamsFunctions(
+      [
+        createToolCall('async_tool', {}),
+      ],
+      [
+        asyncTool,
+      ],
+      createRequest(),
+    );
+
+    expect(result.model).toBe('openai/gpt-5');
+  });
+
+  it('runs a tool once per call when it was called multiple times', async () => {
+    let invocations = 0;
+    const countingTool = tool({
+      name: 'counter',
+      inputSchema: z.object({}),
+      execute: async () => 'done',
+      nextTurnParams: {
+        maxOutputTokens: () => ++invocations,
+      },
+    });
+
+    const result = await executeNextTurnParamsFunctions(
+      [
+        createToolCall('counter', {}),
+        createToolCall('counter', {}),
+      ],
+      [
+        countingTool,
+      ],
+      createRequest(),
+    );
+
+    expect(invocations).toBe(2);
+    expect(result.maxOutputTokens).toBe(2);
+  });
+
+  it('ignores tools that were not called', async () => {
+    const calledTool = tool({
+      name: 'called',
+      inputSchema: z.object({}),
+      execute: async () => 'done',
+      nextTurnParams: {
+        temperature: () => 0.1,
+      },
+    });
+    const uncalledTool = tool({
+      name: 'uncalled',
+      inputSchema: z.object({}),
+      execute: async () => 'done',
+      nextTurnParams: {
+        temperature: () => 0.9,
+      },
+    });
+
+    const result = await executeNextTurnParamsFunctions(
+      [
+        createToolCall('called', {}),
+      ],
+      [
+        calledTool,
+        uncalledTool,
+      ],
+      createRequest(),
+    );
+
+    expect(result.temperature).toBe(0.1);
+  });
+
+  it('skips server tools entirely', async () => {
+    const serverTool = {
+      _brand: 'server-tool',
+      function: {
+        name: 'server_search',
+        nextTurnParams: {
+          temperature: () => 0.0,
+        },
+      },
+    } as unknown as Tool;
+
+    const result = await executeNextTurnParamsFunctions(
+      [
+        createToolCall('server_search', {}),
+      ],
+      [
+        serverTool,
+      ],
+      createRequest({
+        temperature: 0.7,
+      } as Partial<models.ResponsesRequest>),
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it('throws a descriptive error when tool call arguments are not an object', async () => {
+    const strictTool = tool({
+      name: 'strict',
+      inputSchema: z.object({}),
+      execute: async () => 'done',
+      nextTurnParams: {
+        temperature: () => 0.5,
+      },
+    });
+
+    await expect(
+      executeNextTurnParamsFunctions(
+        [
+          createToolCall('strict', [
+            'not',
+            'an',
+            'object',
+          ]),
+        ],
+        [
+          strictTool,
+        ],
+        createRequest(),
+      ),
+    ).rejects.toThrow('Tool call arguments for strict must be an object, got array');
+
+    await expect(
+      executeNextTurnParamsFunctions(
+        [
+          createToolCall('strict', 'a-string'),
+        ],
+        [
+          strictTool,
+        ],
+        createRequest(),
+      ),
+    ).rejects.toThrow('Tool call arguments for strict must be an object, got string');
+  });
+
+  it('warns and skips invalid nextTurnParams keys outside production', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const oddTool = tool({
+      name: 'odd',
+      inputSchema: z.object({}),
+      execute: async () => 'done',
+      nextTurnParams: {
+        bogusKey: () => 42,
+        temperature: () => 0.3,
+      } as never,
+    });
+
+    const result = await executeNextTurnParamsFunctions(
+      [
+        createToolCall('odd', {}),
+      ],
+      [
+        oddTool,
+      ],
+      createRequest(),
+    );
+
+    expect(result).toEqual({
+      temperature: 0.3,
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid nextTurnParams key "bogusKey" in tool "odd"'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('ignores non-function values in nextTurnParams', async () => {
+    const weirdTool = tool({
+      name: 'weird',
+      inputSchema: z.object({}),
+      execute: async () => 'done',
+      nextTurnParams: {
+        temperature: 0.5,
+      } as never,
+    });
+
+    const result = await executeNextTurnParamsFunctions(
+      [
+        createToolCall('weird', {}),
+      ],
+      [
+        weirdTool,
+      ],
+      createRequest(),
+    );
+
+    expect(result).toEqual({});
+  });
+});

--- a/packages/agent/tests/unit/stop-conditions.test.ts
+++ b/packages/agent/tests/unit/stop-conditions.test.ts
@@ -1,0 +1,326 @@
+import type * as models from '@openrouter/sdk/models';
+import { describe, expect, it } from 'vitest';
+import {
+  finishReasonIs,
+  hasToolCall,
+  isStopConditionMet,
+  maxCost,
+  maxTokensUsed,
+  stepCountIs,
+} from '../../src/lib/stop-conditions.js';
+import type { StepResult } from '../../src/lib/tool-types.js';
+
+/**
+ * Creates a minimal StepResult for stop-condition testing.
+ * Stop conditions only read `toolCalls`, `usage`, and `finishReason`,
+ * so the remaining fields are inert placeholders.
+ */
+function makeStep(overrides?: {
+  toolCallNames?: string[];
+  usage?: {
+    totalTokens?: number;
+    cost?: number;
+  } | null;
+  finishReason?: string;
+}): StepResult {
+  return {
+    stepType: 'initial',
+    text: '',
+    toolCalls: (overrides?.toolCallNames ?? []).map((name) => ({
+      name,
+    })) as StepResult['toolCalls'],
+    toolResults: [],
+    response: {} as models.OpenResponsesResult,
+    usage: overrides?.usage === null ? null : (overrides?.usage as models.Usage | undefined),
+    finishReason: overrides?.finishReason,
+  };
+}
+
+describe('stepCountIs', () => {
+  it('returns false when below the threshold', () => {
+    expect(
+      stepCountIs(2)({
+        steps: [
+          makeStep(),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true when the threshold is reached exactly', () => {
+    expect(
+      stepCountIs(2)({
+        steps: [
+          makeStep(),
+          makeStep(),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true when the threshold is exceeded', () => {
+    expect(
+      stepCountIs(1)({
+        steps: [
+          makeStep(),
+          makeStep(),
+          makeStep(),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for zero steps when threshold is zero', () => {
+    expect(
+      stepCountIs(0)({
+        steps: [],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('hasToolCall', () => {
+  it('returns false when no step contains the tool', () => {
+    const steps = [
+      makeStep({
+        toolCallNames: [
+          'search',
+          'browse',
+        ],
+      }),
+    ];
+    expect(
+      hasToolCall('email')({
+        steps,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true when any step contains the tool', () => {
+    const steps = [
+      makeStep({
+        toolCallNames: [
+          'search',
+        ],
+      }),
+      makeStep({
+        toolCallNames: [
+          'email',
+        ],
+      }),
+    ];
+    expect(
+      hasToolCall('email')({
+        steps,
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for empty steps', () => {
+    expect(
+      hasToolCall('search')({
+        steps: [],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('maxTokensUsed', () => {
+  it('sums totalTokens across steps', () => {
+    const steps = [
+      makeStep({
+        usage: {
+          totalTokens: 400,
+        },
+      }),
+      makeStep({
+        usage: {
+          totalTokens: 700,
+        },
+      }),
+    ];
+    expect(
+      maxTokensUsed(1000)({
+        steps,
+      }),
+    ).toBe(true);
+    expect(
+      maxTokensUsed(1101)({
+        steps,
+      }),
+    ).toBe(false);
+  });
+
+  it('treats missing usage as zero tokens', () => {
+    const steps = [
+      makeStep(),
+      makeStep({
+        usage: null,
+      }),
+    ];
+    expect(
+      maxTokensUsed(1)({
+        steps,
+      }),
+    ).toBe(false);
+  });
+
+  it('treats missing totalTokens as zero', () => {
+    const steps = [
+      makeStep({
+        usage: {},
+      }),
+    ];
+    expect(
+      maxTokensUsed(0)({
+        steps,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('maxCost', () => {
+  it('sums cost across steps', () => {
+    const steps = [
+      makeStep({
+        usage: {
+          cost: 0.3,
+        },
+      }),
+      makeStep({
+        usage: {
+          cost: 0.25,
+        },
+      }),
+    ];
+    expect(
+      maxCost(0.5)({
+        steps,
+      }),
+    ).toBe(true);
+    expect(
+      maxCost(0.6)({
+        steps,
+      }),
+    ).toBe(false);
+  });
+
+  it('treats missing cost as zero', () => {
+    expect(
+      maxCost(0.01)({
+        steps: [
+          makeStep({
+            usage: {},
+          }),
+        ],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('finishReasonIs', () => {
+  it('returns true when any step has the finish reason', () => {
+    const steps = [
+      makeStep({
+        finishReason: 'stop',
+      }),
+      makeStep({
+        finishReason: 'length',
+      }),
+    ];
+    expect(
+      finishReasonIs('length')({
+        steps,
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when no step has the finish reason', () => {
+    const steps = [
+      makeStep({
+        finishReason: 'stop',
+      }),
+      makeStep(),
+    ];
+    expect(
+      finishReasonIs('length')({
+        steps,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isStopConditionMet', () => {
+  it('returns false when no conditions are provided', async () => {
+    await expect(
+      isStopConditionMet({
+        stopConditions: [],
+        steps: [],
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it('returns false when all conditions are false', async () => {
+    await expect(
+      isStopConditionMet({
+        stopConditions: [
+          stepCountIs(5),
+          hasToolCall('search'),
+        ],
+        steps: [
+          makeStep(),
+        ],
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it('returns true when ANY condition is true (OR logic)', async () => {
+    await expect(
+      isStopConditionMet({
+        stopConditions: [
+          stepCountIs(5),
+          stepCountIs(1),
+        ],
+        steps: [
+          makeStep(),
+        ],
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it('supports async stop conditions', async () => {
+    const asyncCondition = async () => true;
+    await expect(
+      isStopConditionMet({
+        stopConditions: [
+          asyncCondition,
+        ],
+        steps: [],
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it('treats undefined condition results as not-stopping', async () => {
+    const undefinedCondition = () => undefined as unknown as boolean;
+    await expect(
+      isStopConditionMet({
+        stopConditions: [
+          undefinedCondition,
+        ],
+        steps: [],
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it('propagates rejections from failing conditions', async () => {
+    const failingCondition = () => Promise.reject(new Error('condition exploded'));
+    await expect(
+      isStopConditionMet({
+        stopConditions: [
+          failingCondition,
+        ],
+        steps: [],
+      }),
+    ).rejects.toThrow('condition exploded');
+  });
+});

--- a/packages/agent/tests/unit/tool-orchestrator.test.ts
+++ b/packages/agent/tests/unit/tool-orchestrator.test.ts
@@ -1,0 +1,672 @@
+import type * as models from '@openrouter/sdk/models';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { tool } from '../../src/lib/tool.js';
+import {
+  executeToolLoop,
+  getToolExecutionErrors,
+  hasToolExecutionErrors,
+  summarizeToolExecutions,
+  toolResultsToMap,
+} from '../../src/lib/tool-orchestrator.js';
+import type { Tool, ToolExecutionResult } from '../../src/lib/tool-types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function functionCallItem(
+  callId: string,
+  name: string,
+  args: Record<string, unknown>,
+): models.OutputFunctionCallItem {
+  return {
+    type: 'function_call',
+    callId,
+    name,
+    arguments: JSON.stringify(args),
+    id: callId,
+    status: 'completed',
+  } as unknown as models.OutputFunctionCallItem;
+}
+
+function responseWith(...items: unknown[]): models.OpenResponsesResult {
+  return {
+    output: items,
+  } as unknown as models.OpenResponsesResult;
+}
+
+function terminalResponse(): models.OpenResponsesResult {
+  return responseWith({
+    type: 'message',
+    role: 'assistant',
+    content: [],
+  });
+}
+
+/**
+ * A sendRequest stub that returns queued responses in order.
+ */
+function queueSendRequest(...responses: models.OpenResponsesResult[]) {
+  let index = 0;
+  return vi.fn(async (_input: models.InputsUnion, _tools: unknown[]) => {
+    const response = responses[index] ?? responses[responses.length - 1];
+    index++;
+    if (!response) {
+      throw new Error('sendRequest called with no queued responses');
+    }
+    return response;
+  });
+}
+
+const initialRequest = {
+  model: 'openai/gpt-4',
+  input: [
+    {
+      role: 'user',
+      content: 'hi',
+    },
+  ],
+} as unknown as models.ResponsesRequest;
+
+const initialInput = [
+  {
+    role: 'user',
+    content: 'hi',
+  },
+] as unknown as models.InputsUnion;
+
+// ---------------------------------------------------------------------------
+// executeToolLoop
+// ---------------------------------------------------------------------------
+
+describe('executeToolLoop', () => {
+  it('returns immediately when the initial response has no tool calls', async () => {
+    const response = terminalResponse();
+    const sendRequest = queueSendRequest(response);
+
+    const result = await executeToolLoop(sendRequest, initialInput, initialRequest, [], []);
+
+    expect(result.finalResponse).toBe(response);
+    expect(result.allResponses).toEqual([
+      response,
+    ]);
+    expect(result.toolExecutionResults).toEqual([]);
+    expect(result.conversationInput).toBe(initialInput);
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('executes a tool call and loops until the model stops calling tools', async () => {
+    const addTool = tool({
+      name: 'add',
+      inputSchema: z.object({
+        a: z.number(),
+        b: z.number(),
+      }),
+      execute: async ({ a, b }) => ({
+        sum: a + b,
+      }),
+    });
+    const first = responseWith(
+      functionCallItem('call_1', 'add', {
+        a: 2,
+        b: 3,
+      }),
+    );
+    const second = terminalResponse();
+    const sendRequest = queueSendRequest(first, second);
+
+    const result = await executeToolLoop(
+      sendRequest,
+      initialInput,
+      initialRequest,
+      [
+        addTool,
+      ],
+      [],
+    );
+
+    expect(sendRequest).toHaveBeenCalledTimes(2);
+    expect(result.allResponses).toEqual([
+      first,
+      second,
+    ]);
+    expect(result.finalResponse).toBe(second);
+    expect(result.toolExecutionResults).toHaveLength(1);
+    expect(result.toolExecutionResults[0]).toMatchObject({
+      toolCallId: 'call_1',
+      toolName: 'add',
+      source: 'client',
+      result: {
+        sum: 5,
+      },
+    });
+  });
+
+  it('supports multiple rounds of tool calls', async () => {
+    const pingTool = tool({
+      name: 'ping',
+      inputSchema: z.object({}),
+      execute: async () => 'pong',
+    });
+    const round1 = responseWith(functionCallItem('call_1', 'ping', {}));
+    const round2 = responseWith(functionCallItem('call_2', 'ping', {}));
+    const end = terminalResponse();
+    const sendRequest = queueSendRequest(round1, round2, end);
+
+    const result = await executeToolLoop(
+      sendRequest,
+      initialInput,
+      initialRequest,
+      [
+        pingTool,
+      ],
+      [],
+    );
+
+    expect(sendRequest).toHaveBeenCalledTimes(3);
+    expect(result.allResponses).toHaveLength(3);
+    expect(result.toolExecutionResults.map((r) => r.toolCallId)).toEqual([
+      'call_1',
+      'call_2',
+    ]);
+  });
+
+  it('executes multiple tool calls in one round', async () => {
+    const echoTool = tool({
+      name: 'echo',
+      inputSchema: z.object({
+        value: z.string(),
+      }),
+      execute: async ({ value }) => value,
+    });
+    const first = responseWith(
+      functionCallItem('call_a', 'echo', {
+        value: 'one',
+      }),
+      functionCallItem('call_b', 'echo', {
+        value: 'two',
+      }),
+    );
+    const sendRequest = queueSendRequest(first, terminalResponse());
+
+    const result = await executeToolLoop(
+      sendRequest,
+      initialInput,
+      initialRequest,
+      [
+        echoTool,
+      ],
+      [],
+    );
+
+    expect(result.toolExecutionResults).toHaveLength(2);
+    expect(result.toolExecutionResults.map((r) => r.result)).toEqual([
+      'one',
+      'two',
+    ]);
+  });
+
+  it('returns an error result for calls to unknown tools', async () => {
+    const knownTool = tool({
+      name: 'known',
+      inputSchema: z.object({}),
+      execute: async () => 'ok',
+    });
+    const first = responseWith(
+      functionCallItem('call_1', 'known', {}),
+      functionCallItem('call_2', 'ghost', {}),
+    );
+    const sendRequest = queueSendRequest(first, terminalResponse());
+
+    const result = await executeToolLoop(
+      sendRequest,
+      initialInput,
+      initialRequest,
+      [
+        knownTool,
+      ],
+      [],
+    );
+
+    const ghost = result.toolExecutionResults.find((r) => r.toolCallId === 'call_2');
+    expect(ghost?.error?.message).toBe('Tool "ghost" not found in tool definitions');
+    expect(ghost?.source).toBe('client');
+    expect(
+      result.toolExecutionResults.find((r) => r.toolCallId === 'call_1')?.error,
+    ).toBeUndefined();
+  });
+
+  it('stops without executing when no tool can be auto-resolved (manual tools)', async () => {
+    const manualTool = tool({
+      name: 'needs_human',
+      inputSchema: z.object({
+        question: z.string(),
+      }),
+      execute: false,
+    });
+    const first = responseWith(
+      functionCallItem('call_1', 'needs_human', {
+        question: '?',
+      }),
+    );
+    const sendRequest = queueSendRequest(first);
+
+    const result = await executeToolLoop(
+      sendRequest,
+      initialInput,
+      initialRequest,
+      [
+        manualTool,
+      ],
+      [],
+    );
+
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+    expect(result.toolExecutionResults).toEqual([]);
+    expect(result.finalResponse).toBe(first);
+  });
+
+  it('captures execute failures as error results and keeps looping', async () => {
+    const failTool = tool({
+      name: 'explodes',
+      inputSchema: z.object({}),
+      execute: async () => {
+        throw new Error('kaboom');
+      },
+    });
+    const first = responseWith(functionCallItem('call_1', 'explodes', {}));
+    const sendRequest = queueSendRequest(first, terminalResponse());
+
+    const result = await executeToolLoop(
+      sendRequest,
+      initialInput,
+      initialRequest,
+      [
+        failTool,
+      ],
+      [],
+    );
+
+    expect(result.toolExecutionResults).toHaveLength(1);
+    expect(result.toolExecutionResults[0]?.error?.message).toBe('kaboom');
+    expect(sendRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('marks failures from MCP-branded tools with source "mcp"', async () => {
+    const mcpTool = {
+      ...tool({
+        name: 'mcp_tool',
+        inputSchema: z.object({}),
+        execute: async () => {
+          throw new Error('mcp failure');
+        },
+      }),
+      _mcp: true,
+    } as unknown as Tool;
+    const first = responseWith(functionCallItem('call_1', 'mcp_tool', {}));
+    const sendRequest = queueSendRequest(first, terminalResponse());
+
+    const result = await executeToolLoop(
+      sendRequest,
+      initialInput,
+      initialRequest,
+      [
+        mcpTool,
+      ],
+      [],
+    );
+
+    expect(result.toolExecutionResults[0]).toMatchObject({
+      source: 'mcp',
+      result: null,
+    });
+    expect(result.toolExecutionResults[0]?.error?.message).toBe('mcp failure');
+  });
+
+  it('filters out null results (HITL tool pausing) but continues the loop', async () => {
+    const hitlTool = tool({
+      name: 'approve',
+      inputSchema: z.object({}),
+      outputSchema: z.object({
+        approved: z.boolean(),
+      }),
+      onToolCalled: () => null,
+    });
+    const first = responseWith(functionCallItem('call_1', 'approve', {}));
+    const sendRequest = queueSendRequest(first, terminalResponse());
+
+    const result = await executeToolLoop(
+      sendRequest,
+      initialInput,
+      initialRequest,
+      [
+        hitlTool,
+      ],
+      [],
+    );
+
+    expect(result.toolExecutionResults).toEqual([]);
+    expect(sendRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    'background',
+    'deferred',
+  ] as const)('rejects %s-lifecycle tools without invoking run', async (lifecycle) => {
+    const run = vi.fn(async () => ({
+      url: 'https://example.com',
+    }));
+    const asyncTool = tool({
+      name: 'slow_render',
+      lifecycle,
+      inputSchema: z.object({
+        script: z.string(),
+      }),
+      outputSchema: z.object({
+        url: z.string(),
+      }),
+      ack: 'started',
+      graceMs: 0,
+      run,
+    } as never);
+    const first = responseWith(
+      functionCallItem('call_1', 'slow_render', {
+        script: 'x',
+      }),
+    );
+    const sendRequest = queueSendRequest(first, terminalResponse());
+
+    const result = await executeToolLoop(
+      sendRequest,
+      initialInput,
+      initialRequest,
+      [
+        asyncTool,
+      ],
+      [],
+    );
+
+    expect(run).not.toHaveBeenCalled();
+    expect(result.toolExecutionResults[0]?.error?.message).toContain(
+      `Tool "slow_render" uses an async lifecycle ('${lifecycle}')`,
+    );
+    expect(result.toolExecutionResults[0]?.error?.message).toContain('callModel');
+  });
+
+  it('forwards generator preliminary results to onPreliminaryResult', async () => {
+    const progressTool = tool({
+      name: 'progress',
+      inputSchema: z.object({}),
+      eventSchema: z.object({
+        pct: z.number(),
+      }),
+      outputSchema: z.object({
+        done: z.boolean(),
+      }),
+      execute: async function* () {
+        yield {
+          pct: 50,
+        };
+        yield {
+          done: true,
+        };
+      },
+    });
+    const first = responseWith(functionCallItem('call_1', 'progress', {}));
+    const sendRequest = queueSendRequest(first, terminalResponse());
+    const onPreliminaryResult = vi.fn();
+
+    const result = await executeToolLoop(
+      sendRequest,
+      initialInput,
+      initialRequest,
+      [
+        progressTool,
+      ],
+      [],
+      {
+        onPreliminaryResult,
+      },
+    );
+
+    expect(onPreliminaryResult).toHaveBeenCalledWith('call_1', {
+      pct: 50,
+    });
+    expect(result.toolExecutionResults[0]).toMatchObject({
+      result: {
+        done: true,
+      },
+      preliminaryResults: [
+        {
+          pct: 50,
+        },
+      ],
+    });
+  });
+
+  it('applies nextTurnParams input changes to the conversation', async () => {
+    const newInput = [
+      {
+        role: 'user',
+        content: 'rewritten',
+      },
+    ] as unknown as models.InputsUnion;
+    const steeringTool = tool({
+      name: 'steer',
+      inputSchema: z.object({}),
+      execute: async () => 'ok',
+      nextTurnParams: {
+        input: () => newInput,
+      },
+    });
+    const first = responseWith(functionCallItem('call_1', 'steer', {}));
+    const sendRequest = queueSendRequest(first, terminalResponse());
+
+    const result = await executeToolLoop(
+      sendRequest,
+      initialInput,
+      initialRequest,
+      [
+        steeringTool,
+      ],
+      [],
+    );
+
+    expect(result.conversationInput).toEqual(newInput);
+    expect(sendRequest).toHaveBeenLastCalledWith(newInput, []);
+  });
+
+  it('keeps the original conversation input when nextTurnParams changes nothing', async () => {
+    const plainTool = tool({
+      name: 'plain',
+      inputSchema: z.object({}),
+      execute: async () => 'ok',
+    });
+    const first = responseWith(functionCallItem('call_1', 'plain', {}));
+    const sendRequest = queueSendRequest(first, terminalResponse());
+
+    const result = await executeToolLoop(
+      sendRequest,
+      initialInput,
+      initialRequest,
+      [
+        plainTool,
+      ],
+      [],
+    );
+
+    expect(result.conversationInput).toBe(initialInput);
+  });
+
+  it('keeps conversation input aligned with the request when params were computed', async () => {
+    const tuningTool = tool({
+      name: 'tune',
+      inputSchema: z.object({}),
+      execute: async () => 'ok',
+      nextTurnParams: {
+        temperature: () => 0.2,
+      },
+    });
+    const first = responseWith(functionCallItem('call_1', 'tune', {}));
+    const sendRequest = queueSendRequest(first, terminalResponse());
+
+    const result = await executeToolLoop(
+      sendRequest,
+      initialInput,
+      initialRequest,
+      [
+        tuningTool,
+      ],
+      [],
+    );
+
+    // computedParams exist but contain no input override, so the loop adopts
+    // the (unmodified) request input.
+    expect(result.conversationInput).toEqual(initialRequest.input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Result helper functions
+// ---------------------------------------------------------------------------
+
+function makeResult(overrides?: Partial<ToolExecutionResult<Tool>>): ToolExecutionResult<Tool> {
+  return {
+    toolCallId: 'call_1',
+    toolName: 'some_tool',
+    source: 'client',
+    result: 'ok',
+    ...overrides,
+  } as ToolExecutionResult<Tool>;
+}
+
+describe('toolResultsToMap', () => {
+  it('maps results by toolCallId', () => {
+    const results = [
+      makeResult({
+        toolCallId: 'a',
+        result: 1,
+      }),
+      makeResult({
+        toolCallId: 'b',
+        result: 2,
+        preliminaryResults: [
+          'p',
+        ],
+      }),
+    ];
+
+    const map = toolResultsToMap(results);
+
+    expect(map.get('a')).toEqual({
+      result: 1,
+      preliminaryResults: undefined,
+    });
+    expect(map.get('b')).toEqual({
+      result: 2,
+      preliminaryResults: [
+        'p',
+      ],
+    });
+    expect(map.size).toBe(2);
+  });
+
+  it('returns an empty map for no results', () => {
+    expect(toolResultsToMap([]).size).toBe(0);
+  });
+});
+
+describe('summarizeToolExecutions', () => {
+  it('summarizes successes and errors', () => {
+    const summary = summarizeToolExecutions([
+      makeResult({
+        toolName: 'good',
+        toolCallId: 'a',
+      }),
+      makeResult({
+        toolName: 'chatty',
+        toolCallId: 'b',
+        preliminaryResults: [
+          1,
+          2,
+        ],
+      }),
+      makeResult({
+        toolName: 'bad',
+        toolCallId: 'c',
+        result: null,
+        error: new Error('nope'),
+      }),
+    ]);
+
+    expect(summary).toBe(
+      [
+        '✅ good (a): SUCCESS',
+        '✅ chatty (b): SUCCESS (2 preliminary results)',
+        '❌ bad (c): ERROR - nope',
+      ].join('\n'),
+    );
+  });
+
+  it('returns an empty string for no results', () => {
+    expect(summarizeToolExecutions([])).toBe('');
+  });
+});
+
+describe('hasToolExecutionErrors', () => {
+  it('is false when no result has an error', () => {
+    expect(
+      hasToolExecutionErrors([
+        makeResult(),
+      ]),
+    ).toBe(false);
+    expect(hasToolExecutionErrors([])).toBe(false);
+  });
+
+  it('is true when any result has an error', () => {
+    expect(
+      hasToolExecutionErrors([
+        makeResult(),
+        makeResult({
+          error: new Error('x'),
+          result: null,
+        }),
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe('getToolExecutionErrors', () => {
+  it('returns only the errors from failed results', () => {
+    const boom = new Error('boom');
+    const errors = getToolExecutionErrors([
+      makeResult(),
+      makeResult({
+        toolCallId: 'b',
+        error: boom,
+        result: null,
+      }),
+      makeResult({
+        toolCallId: 'c',
+        error: new Error('pow'),
+        result: null,
+      }),
+    ]);
+
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toBe(boom);
+    expect(errors.map((e) => e.message)).toEqual([
+      'boom',
+      'pow',
+    ]);
+  });
+
+  it('returns an empty array when nothing failed', () => {
+    expect(
+      getToolExecutionErrors([
+        makeResult(),
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/packages/agent/tests/unit/turn-context.test.ts
+++ b/packages/agent/tests/unit/turn-context.test.ts
@@ -1,0 +1,114 @@
+import type * as models from '@openrouter/sdk/models';
+import { describe, expect, it } from 'vitest';
+import { buildTurnContext, normalizeInputToArray } from '../../src/lib/turn-context.js';
+
+describe('buildTurnContext', () => {
+  it('builds a minimal context with only numberOfTurns', () => {
+    const context = buildTurnContext({
+      numberOfTurns: 0,
+    });
+
+    expect(context.numberOfTurns).toBe(0);
+    expect(context.toolCall).toBeUndefined();
+    expect(context.turnRequest).toBeUndefined();
+  });
+
+  it('includes the tool call when provided', () => {
+    const toolCall = {
+      type: 'function_call',
+      callId: 'call_1',
+      name: 'search',
+      arguments: '{}',
+      id: 'call_1',
+    } as models.FunctionCallItem;
+
+    const context = buildTurnContext({
+      numberOfTurns: 2,
+      toolCall,
+    });
+
+    expect(context.numberOfTurns).toBe(2);
+    expect(context.toolCall).toBe(toolCall);
+    expect(context.turnRequest).toBeUndefined();
+  });
+
+  it('includes the turn request when provided', () => {
+    const turnRequest = {
+      model: 'openai/gpt-4',
+      input: [],
+    } as unknown as models.ResponsesRequest;
+
+    const context = buildTurnContext({
+      numberOfTurns: 1,
+      turnRequest,
+    });
+
+    expect(context.turnRequest).toBe(turnRequest);
+  });
+
+  it('includes both toolCall and turnRequest together', () => {
+    const toolCall = {
+      type: 'function_call',
+      callId: 'call_2',
+      name: 'browse',
+      arguments: '{}',
+      id: 'call_2',
+    } as models.FunctionCallItem;
+    const turnRequest = {
+      model: 'openai/gpt-4',
+    } as models.ResponsesRequest;
+
+    const context = buildTurnContext({
+      numberOfTurns: 3,
+      toolCall,
+      turnRequest,
+    });
+
+    expect(context).toEqual({
+      numberOfTurns: 3,
+      toolCall,
+      turnRequest,
+    });
+  });
+});
+
+describe('normalizeInputToArray', () => {
+  it('converts string input to a single user message', () => {
+    const result = normalizeInputToArray('Hello!');
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: 'Hello!',
+      },
+    ]);
+  });
+
+  it('passes array input through unchanged (same reference)', () => {
+    const input = [
+      {
+        role: 'user',
+        content: 'hi',
+      },
+      {
+        role: 'assistant',
+        content: 'hello',
+      },
+    ] as unknown as models.InputsUnion;
+
+    const result = normalizeInputToArray(input);
+
+    expect(result).toBe(input);
+  });
+
+  it('handles empty string input', () => {
+    const result = normalizeInputToArray('');
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: '',
+      },
+    ]);
+  });
+});

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -11,6 +11,17 @@ export default defineConfig({
       enabled: true,
       provider: 'v8',
       include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts'],
+      reporter: ['text', 'json-summary', 'html'],
+      // Coverage ratchet: thresholds are pinned at current levels. Any PR
+      // that lowers coverage fails the unit-test job. When you raise
+      // coverage, raise these floors in the same PR.
+      thresholds: {
+        statements: 82,
+        branches: 74,
+        functions: 88,
+        lines: 82,
+      },
     },
     globals: true,
     environment: 'node',

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -63,7 +63,7 @@
     "gen:version": "node scripts/gen-version.mjs",
     "build": "node scripts/gen-version.mjs && tsc",
     "test": "vitest --run --project unit",
-    "test:e2e": "vitest --run --project e2e",
+    "test:e2e": "vitest --run --project e2e --coverage.enabled=false",
     "test:watch": "vitest --watch --project unit",
     "typecheck": "tsc --noEmit",
     "compile": "node scripts/gen-version.mjs && tsc"

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -7,6 +7,22 @@ config({
 
 export default defineConfig({
   test: {
+    coverage: {
+      enabled: true,
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts'],
+      reporter: ['text', 'json-summary', 'html'],
+      // Coverage ratchet: thresholds are pinned at current levels. Any PR
+      // that lowers coverage fails the unit-test job. When you raise
+      // coverage, raise these floors in the same PR.
+      thresholds: {
+        statements: 90,
+        branches: 80,
+        functions: 92,
+        lines: 90,
+      },
+    },
     globals: true,
     environment: 'node',
     env: {


### PR DESCRIPTION
## Summary

Makes CI checks on PRs the actual gate they were pretending to be. Previously coverage was collected but **nothing enforced it**, the most critical file (`tool-orchestrator.ts`) had **0% coverage**, and the e2e job **silently passed** whenever the API key was missing.

## What changes

### 1. Coverage thresholds, pinned and enforced
- Both packages' vitest configs now declare v8 thresholds; any PR that lowers coverage fails the `unit-tests` job (verified: exit 1 on breach).
- Floors are pinned at current levels — a ratchet, so coverage can only go up:

| Package | Stmts | Branch | Funcs | Lines | Thresholds |
|---|---|---|---|---|---|
| agent | 83.0% | 74.6% | 88.6% | 82.9% | 82 / 74 / 88 / 82 |
| mcp | 93.4% | 82.4% | 94.9% | 93.5% | 90 / 80 / 92 / 90 |

- Test files (`src/**/*.test.ts`) excluded from coverage accounting.
- CI posts a per-package coverage table to the job summary and uploads HTML/JSON reports as artifacts.

### 2. +76 unit tests closing the worst gaps (`@openrouter/agent`)
| File | Before | After |
|---|---|---|
| `tool-orchestrator.ts` (the tool execution loop, public API) | **0%** | 89% |
| `claude-type-guards.ts` | **0%** | 100% |
| `stop-conditions.ts` | 32% (0% branch) | 100% |
| `next-turn-params.ts` | 34% | 100% |
| `turn-context.ts` | 40% | 100% |

Orchestrator tests cover: multi-round loops, unknown/manual/failing tools, HITL null-pauses, background/deferred lifecycle rejection (asserting `run` is never invoked), generator preliminary-result forwarding, and `nextTurnParams` conversation steering.

### 3. CI workflow hardening
- **E2E no longer fails open**: missing `OPENROUTER_API_KEY` is now a hard error — *except* on fork PRs, where secrets are legitimately unavailable (skip with warning).
- New triggers: `push` to main + nightly schedule (full suite incl. live e2e).
- New **`ci-status` aggregator job**: point branch protection at this single check. The required set lives in one `needs:` list, so a renamed or deleted job can never leave the gate green, and adding a check automatically extends it.
- `permissions: contents: read`, PR concurrency cancellation.

### 4. Drive-by fix
Removed a write-only `steered` variable in `agent-tool.test.ts` that was failing biome — **the lint gate on main is currently red**, which this PR also fixes.

## Verification
- `pnpm lint`, `pnpm typecheck`, `pnpm test` all green (909 agent + 168 mcp tests).
- Threshold breach confirmed to fail the run (exit 1).
- `ci.yaml` parses; coverage-summary script output verified.

## Not done (deliberately)
- E2E tests still hit the live OpenRouter API — converting them to hermetic/recorded tests is a follow-up. They're now at least *honest*: required when secrets exist, explicitly skipped only on forks.
- Branch protection settings (`ci-status` as required check) must be flipped in repo settings after merge.

## Remaining known gaps
- `stream-transformers.ts` (50%, 38% branch) and `stream-type-guards.ts` (69%) are the next biggest under-tested areas.
- The `allSettled` rejection path in `executeToolLoop` is effectively unreachable via public APIs (executor converts failures to error results) — noted in tests rather than covered with mocks.