### PR TITLE
fix(release): gate the release train on CI, not a required perry/review

### DIFF
--- a/.github/scripts/pr-gate.sh
+++ b/.github/scripts/pr-gate.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 #
-# pr-gate.sh — poll a bump PR until Perry + CI reach a terminal state, then
+# pr-gate.sh — poll a bump PR until CI reaches a terminal state, then
 # squash-merge it (when AUTO_MERGE=true) or alert and leave it red.
+#
+# The gate is CI: every check on the PR (lint, tests, etc.) must be green,
+# none pending, and no CHANGES_REQUESTED review decision. A check posted by
+# an AI reviewer (perry/review, Devin Review, ...) counts like any other
+# check WHEN it appears — a red one blocks the merge — but no reviewer is
+# *required* to show up: this repo's PRs are gated on CI, and a required
+# reviewer that never runs (perry/review has never posted here) would stall
+# every train run at "waiting for perry/review".
 #
 # This is the self-gating auto-merge: GitHub-native `gh pr merge --auto` cannot
 # be relied on because the repo has no required status checks, so we poll the
@@ -66,7 +74,6 @@ TIMEOUT="${TIMEOUT:-1800}"      # 30 min per vetted head (resets on head adoptio
 # the failure mode turns confusing. Default 50 min leaves headroom to alert
 # cleanly while the token still works.
 MAX_WALL="${MAX_WALL:-3000}"
-PERRY_TIMEOUT="${PERRY_TIMEOUT:-480}" # 8 min for perry/review to appear at all
 SETTLE="${SETTLE:-45}"
 
 AI_REVIEWERS='perry/review|Devin Review|Graphite / AI Reviews|codex|claude'
@@ -146,18 +153,13 @@ FAIL = {"FAILURE","ERROR","CANCELLED","TIMED_OUT","ACTION_REQUIRED","STARTUP_FAI
 PENDING = {"PENDING","IN_PROGRESS","QUEUED","EXPECTED","WAITING"}
 PASS_REVIEW = {"SUCCESS","NEUTRAL","SKIPPED"}
 
-reasons = []
 ci_pending = False
-perry_present = False
-perry_terminal = False
 
 for c in checks:
     name, state = c["name"], c["state"]
     if ai.search(name):
-        if name == "perry/review":
-            perry_present = True
-            if state not in PENDING:
-                perry_terminal = True
+        # AI reviewer checks are not required to exist, but a red one that
+        # did run still blocks — it is a red check on the PR like any other.
         if state not in PASS_REVIEW and state not in PENDING:
             print(f"FAIL_REVIEWER", file=sys.stderr)
             print(f"reviewer {name}={state}")
@@ -178,8 +180,6 @@ if meta.get("reviewDecision") == "CHANGES_REQUESTED":
 # Not failing. Decide PASS vs PENDING.
 if ci_pending:
     print("PENDING", file=sys.stderr); print("CI still running"); sys.exit(0)
-if not (perry_present and perry_terminal):
-    print("PENDING", file=sys.stderr); print("waiting for perry/review"); sys.exit(0)
 if meta.get("mergeable") != "MERGEABLE":
     print("PENDING", file=sys.stderr); print(f"mergeable={meta.get('mergeable')}"); sys.exit(0)
 print("PASS", file=sys.stderr); print("all green")
@@ -189,15 +189,10 @@ PY
 echo "Gating PR #${PR} on ${REPO} (timeout ${TIMEOUT}s, max wall ${MAX_WALL}s, interval ${INTERVAL}s)"
 START=$(date +%s)
 WALL_START=$START # never reset — see MAX_WALL above
-# perry/review's "never appeared" clock. Reset whenever a new head is adopted
-# mid-gate: the fresh head's checks (perry included) start from scratch, so
-# measuring them against the run's original start time would misreport a
-# routine changesets/action refresh late in the poll as a token misconfig.
-PERRY_START=$START
 LAST_REASON=""
 
 while :; do
-  NOW=$(date +%s); ELAPSED=$((NOW - START)); PERRY_ELAPSED=$((NOW - PERRY_START))
+  NOW=$(date +%s); ELAPSED=$((NOW - START))
 
   # Deadlines at the TOP of the loop, before any branch can `continue` past
   # them: the settle re-check path loops back whenever the verdict flips away
@@ -272,14 +267,13 @@ while :; do
           if [ -n "$NEW_VETTED" ]; then
             echo "PR #${PR} head moved ${EXPECTED_HEAD:0:7} → ${NEW_VETTED:0:7}; new diff passes the scope check — adopting vetted head and re-polling."
             EXPECTED_HEAD="$NEW_VETTED"
-            # Fresh head, fresh checks — restart both clocks. Leaving the
+            # Fresh head, fresh checks — restart the clock. Leaving the
             # overall deadline on the run's original start would misreport a
             # refresh late in the window as "did not settle" when the new
             # head's CI never had a chance to finish. Adoption requires
             # passing the scope re-vet, so this cannot extend a run
             # unboundedly on hostile pushes — those exit 1 above instead.
-            PERRY_START=$(date +%s)
-            START=$PERRY_START
+            START=$(date +%s)
             LAST_REASON=""
             continue
           fi
@@ -300,7 +294,7 @@ while :; do
         # where nobody is watching the run and the PR would sit unmerged
         # until the next scheduled attempt.
         if gh pr merge "$PR" -R "$REPO" --squash --delete-branch "${MATCH_ARGS[@]}"; then
-          slack ":white_check_mark: ${GATE_LABEL} <${PR_URL}|PR #${PR}> passed Perry + CI and was auto-merged."
+          slack ":white_check_mark: ${GATE_LABEL} <${PR_URL}|PR #${PR}> passed CI and was auto-merged."
         else
           slack ":x: ${GATE_LABEL} <${PR_URL}|PR #${PR}>: checks passed but the merge itself failed (branch protection? conflict?). Left open for a human. <${RUN_URL:-$PR_URL}|run>"
           echo "::error::gh pr merge failed for PR #${PR}"
@@ -311,15 +305,6 @@ while :; do
         slack ":white_check_mark: ${GATE_LABEL} <${PR_URL}|PR #${PR}> is green and ready for merge."
       fi
       exit 0
-      ;;
-    PENDING)
-      # If perry/review never even shows up, the PR was likely opened with a
-      # token that doesn't trigger it — surface that rather than hang forever.
-      if [ "$REASON" = "waiting for perry/review" ] && [ "$PERRY_ELAPSED" -ge "$PERRY_TIMEOUT" ]; then
-        slack ":warning: ${GATE_LABEL} <${PR_URL}|PR #${PR}>: perry/review never appeared after ${PERRY_TIMEOUT}s (token/app misconfig?). Not merging. <${RUN_URL:-$PR_URL}|run>"
-        echo "::error::perry/review did not appear within ${PERRY_TIMEOUT}s"
-        exit 1
-      fi
       ;;
   esac
 

--- a/.github/workflows/bump-openrouter-sdk.yaml
+++ b/.github/workflows/bump-openrouter-sdk.yaml
@@ -198,7 +198,7 @@ jobs:
           fi
           exit 1
 
-      - name: Wait for Perry + CI, then merge or alert
+      - name: Wait for CI, then merge or alert
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ needs.bump.outputs.pr_number }}

--- a/.github/workflows/release-train.yaml
+++ b/.github/workflows/release-train.yaml
@@ -4,7 +4,7 @@ name: Release train
 # changesets/action maintains (see publish.yaml). Before this existed, that PR
 # waited for a human to merge it, so shipped features sat unreleased between
 # manual releases. The train bounds that latency: twice a week it finds the
-# Version Packages PR, gates it on Perry + CI via pr-gate.sh (the same gate the
+# Version Packages PR, gates it on CI via pr-gate.sh (the same gate the
 # SDK-bump flow uses), and squash-merges on green — which triggers publish.yaml
 # on push to main and cuts the actual npm release.
 #


### PR DESCRIPTION
## Problem

`pr-gate.sh` refused to PASS until a check named exactly `perry/review` appeared and reached a terminal state. But perry has **never posted a check in this repo** — the AI reviewer that runs here is Devin Review. The requirement was inherited from the SDK bump flow the script was ported from (its default label is still `@openrouter/sdk bump`).

The first train run to ever reach the gate step (dry-run [31418471846](https://github.com/OpenRouterTeam/typescript-agent/actions/runs/31418471846), after the App-token fix) confirmed the stall: `PENDING — waiting for perry/review` until cancelled. Every scheduled train would have died the same way after 480s with "perry/review did not appear".

## Fix

CI is the gate on PRs in this repo:

- **Dropped** the `perry_present`/`perry_terminal` requirement, the `PERRY_TIMEOUT` machinery, and the never-appeared alert path.
- **Kept** fail-closed behavior for anything that *does* post: a red AI-reviewer check still blocks (a red check is a red check), as does `reviewDecision=CHANGES_REQUESTED`.
- **PASS now means**: no failing checks, none pending, mergeable.

## Verification

Ran the modified script live against PR #88 in report-only mode (`AUTO_MERGE=false`): the verdict evaluates correctly end-to-end (it correctly reported `mergeable=UNKNOWN` after #88 was merged mid-poll — the merged-PR state, not a logic error).
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->