### PR TITLE
perf(agent): stop accumulating generator-tool preliminaryResults

### DIFF
--- a/.changeset/drop-preliminary-results.md
+++ b/.changeset/drop-preliminary-results.md
@@ -1,5 +1,5 @@
 ---
-'@openrouter/agent': patch
+'@openrouter/agent': major
 ---
 
-Stop accumulating generator-tool `preliminaryResults` arrays. Yields are still broadcast live; the terminal `tool.result` event no longer copies every yield.
+Stop accumulating generator-tool `preliminaryResults` arrays. Yields are still broadcast live; the terminal `tool.result` event and `ToolExecutionResult` no longer carry the full yield history.

--- a/.changeset/drop-preliminary-results.md
+++ b/.changeset/drop-preliminary-results.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/agent': patch
+---
+
+Stop accumulating generator-tool `preliminaryResults` arrays. Yields are still broadcast live; the terminal `tool.result` event no longer copies every yield.

--- a/packages/agent/src/lib/model-result.ts
+++ b/packages/agent/src/lib/model-result.ts
@@ -972,7 +972,6 @@ export class ModelResult<
     toolName: string,
     source: 'client' | 'mcp',
     result: InferToolOutputsUnion<TTools>,
-    preliminaryResults?: InferToolEventsUnion<TTools>[],
   ): void {
     this.toolEventBroadcaster?.push({
       type: 'tool_result' as const,
@@ -980,9 +979,6 @@ export class ModelResult<
       toolName,
       source,
       result,
-      ...(preliminaryResults?.length && {
-        preliminaryResults,
-      }),
     });
     this.turnBroadcaster?.push({
       type: 'tool.result' as const,
@@ -991,9 +987,6 @@ export class ModelResult<
       source,
       result,
       timestamp: Date.now(),
-      ...(preliminaryResults?.length && {
-        preliminaryResults,
-      }),
     } as CorrelatedResponseStreamEvent<TTools>);
   }
 
@@ -3246,7 +3239,6 @@ export class ModelResult<
         controller: AbortController;
         timeoutMs: number | undefined;
         runBinding: RunBinding;
-        preliminaryResultsForCall: InferToolEventsUnion<TTools>[];
       }
     | {
         type: 'execution';
@@ -3256,7 +3248,6 @@ export class ModelResult<
           result: unknown;
           error?: Error;
         };
-        preliminaryResultsForCall: InferToolEventsUnion<TTools>[];
       }
   > {
     // Universal task-tool dispatch: ONE static tool ("task") handles every
@@ -3288,14 +3279,14 @@ export class ModelResult<
       return hookDenied;
     }
 
-    const preliminaryResultsForCall: InferToolEventsUnion<TTools>[] = [];
-
     const hasBroadcaster = this.toolEventBroadcaster || this.turnBroadcaster;
     const onPreliminaryResult = hasBroadcaster
       ? (callId: string, resultValue: unknown) => {
-          const typedResult = resultValue as InferToolEventsUnion<TTools>;
-          preliminaryResultsForCall.push(typedResult);
-          this.broadcastPreliminaryResult(callId, String(toolCall.name), typedResult);
+          this.broadcastPreliminaryResult(
+            callId,
+            String(toolCall.name),
+            resultValue as InferToolEventsUnion<TTools>,
+          );
         }
       : undefined;
 
@@ -3364,7 +3355,7 @@ export class ModelResult<
       );
 
       if (executed === 'timeout') {
-        return this.buildToolTimeoutOutcome(toolCall, tool, timeoutMs, preliminaryResultsForCall);
+        return this.buildToolTimeoutOutcome(toolCall, tool, timeoutMs);
       }
 
       if (executed.type === 'parse_error') {
@@ -3403,7 +3394,6 @@ export class ModelResult<
           controller,
           timeoutMs,
           runBinding,
-          preliminaryResultsForCall,
         };
       }
 
@@ -3412,7 +3402,6 @@ export class ModelResult<
         toolCall: executed.effectiveToolCall,
         tool,
         result,
-        preliminaryResultsForCall,
       };
     } finally {
       releaseGates();
@@ -3432,7 +3421,6 @@ export class ModelResult<
     toolCall: ParsedToolCall<Tool>,
     tool: Tool,
     timeoutMs: number | undefined,
-    preliminaryResultsForCall: InferToolEventsUnion<TTools>[],
   ): {
     type: 'execution';
     toolCall: ParsedToolCall<Tool>;
@@ -3441,7 +3429,6 @@ export class ModelResult<
       result: unknown;
       error?: Error;
     };
-    preliminaryResultsForCall: InferToolEventsUnion<TTools>[];
   } {
     const message = `Tool "${toolCall.name}" timed out after ${timeoutMs}ms`;
     this.broadcastToolResult(
@@ -3462,7 +3449,6 @@ export class ModelResult<
           code: 'tool_timeout',
         }),
       },
-      preliminaryResultsForCall,
     };
   }
 
@@ -3661,7 +3647,6 @@ export class ModelResult<
         String(value.toolCall.name),
         isMcpTool(value.tool) ? 'mcp' : 'client',
         toolResult,
-        value.preliminaryResultsForCall.length > 0 ? value.preliminaryResultsForCall : undefined,
       );
 
       const outputForModel = await this.computeToolOutputForModel(value);
@@ -4136,7 +4121,6 @@ export class ModelResult<
       result: unknown;
       error?: Error;
     };
-    preliminaryResultsForCall: InferToolEventsUnion<TTools>[];
   }> {
     const taskTool = buildTaskToolStub();
     const answer = (result: unknown, error?: Error) => {
@@ -4160,7 +4144,6 @@ export class ModelResult<
           : {
               result,
             },
-        preliminaryResultsForCall: [] as InferToolEventsUnion<TTools>[],
       };
     };
 

--- a/packages/agent/src/lib/tool-executor.ts
+++ b/packages/agent/src/lib/tool-executor.ts
@@ -337,7 +337,6 @@ export async function executeGeneratorTool(
       extras,
     );
 
-    const preliminaryResults: unknown[] = [];
     let finalResult: unknown;
     let hasFinalResult = false;
     let lastEmittedValue: unknown;
@@ -359,7 +358,6 @@ export async function executeGeneratorTool(
         hasFinalResult = true;
       } else {
         const validatedPreliminary = validateToolOutput(tool.function.eventSchema, event);
-        preliminaryResults.push(validatedPreliminary);
         if (onPreliminaryResult) {
           onPreliminaryResult(toolCall.id, validatedPreliminary);
         }
@@ -387,7 +385,6 @@ export async function executeGeneratorTool(
       toolName: toolCall.name,
       source,
       result: finalResult,
-      preliminaryResults,
     };
   } catch (error) {
     return {

--- a/packages/agent/src/lib/tool-orchestrator.ts
+++ b/packages/agent/src/lib/tool-orchestrator.ts
@@ -186,7 +186,6 @@ export function toolResultsToMap(results: ToolExecutionResult<Tool>[]): Map<
   string,
   {
     result: unknown;
-    preliminaryResults?: unknown[];
   }
 > {
   const map = new Map();
@@ -194,7 +193,6 @@ export function toolResultsToMap(results: ToolExecutionResult<Tool>[]): Map<
   for (const result of results) {
     map.set(result.toolCallId, {
       result: result.result,
-      preliminaryResults: result.preliminaryResults,
     });
   }
 
@@ -211,9 +209,7 @@ export function summarizeToolExecutions(results: ToolExecutionResult<Tool>[]): s
     if (result.error) {
       lines.push(`❌ ${result.toolName} (${result.toolCallId}): ERROR - ${result.error.message}`);
     } else {
-      const prelimCount = result.preliminaryResults?.length ?? 0;
-      const prelimInfo = prelimCount > 0 ? ` (${prelimCount} preliminary results)` : '';
-      lines.push(`✅ ${result.toolName} (${result.toolCallId}): SUCCESS${prelimInfo}`);
+      lines.push(`✅ ${result.toolName} (${result.toolCallId}): SUCCESS`);
     }
   }
 

--- a/packages/agent/src/lib/tool-types.ts
+++ b/packages/agent/src/lib/tool-types.ts
@@ -1213,7 +1213,7 @@ export interface ToolExecutionResult<T extends Tool> {
         : unknown; // Final result (sent to model)
   preliminaryResults?: T extends ToolWithGenerator<$ZodObject<$ZodShape>, infer E>
     ? zodInfer<E>[]
-    : undefined; // All yielded values from generator
+    : undefined; // Kept for type compatibility; no longer populated
   error?: Error;
 }
 
@@ -1365,6 +1365,7 @@ export type ToolResultEvent<
   source: 'client' | 'mcp';
   result: TResult;
   timestamp: number;
+  /** Kept for type compatibility; the runtime no longer copies every yield here. */
   preliminaryResults?: TPreliminaryResults[];
 };
 

--- a/packages/agent/tests/unit/tool-executor-return.test.ts
+++ b/packages/agent/tests/unit/tool-executor-return.test.ts
@@ -45,15 +45,7 @@ describe('executeGeneratorTool - return value capture', () => {
     const result = await executeGeneratorTool(generatorTool, toolCall, mockContext);
 
     expect(result.error).toBeUndefined();
-    expect(result.preliminaryResults).toHaveLength(2);
-    expect(result.preliminaryResults).toEqual([
-      {
-        status: 'working',
-      },
-      {
-        status: 'almost done',
-      },
-    ]);
+    expect(result.preliminaryResults).toBeUndefined();
     // The return value should be captured as the final result
     expect(result.result).toEqual({
       result: 'Done: test',
@@ -91,7 +83,7 @@ describe('executeGeneratorTool - return value capture', () => {
     const result = await executeGeneratorTool(generatorTool, toolCall, mockContext);
 
     expect(result.error).toBeUndefined();
-    expect(result.preliminaryResults).toHaveLength(0);
+    expect(result.preliminaryResults).toBeUndefined();
     expect(result.result).toEqual({
       result: 'Direct: test',
     });
@@ -134,7 +126,7 @@ describe('executeGeneratorTool - return value capture', () => {
     const result = await executeGeneratorTool(generatorTool, toolCall, mockContext);
 
     expect(result.error).toBeUndefined();
-    expect(result.preliminaryResults).toHaveLength(2);
+    expect(result.preliminaryResults).toBeUndefined();
     // Return value should take precedence
     expect(result.result).toEqual({
       finalValue: 'Final: test',

--- a/packages/agent/tests/unit/tool-executor-return.test.ts
+++ b/packages/agent/tests/unit/tool-executor-return.test.ts
@@ -52,6 +52,46 @@ describe('executeGeneratorTool - return value capture', () => {
     });
   });
 
+  it('broadcasts many preliminary results without retaining them on the terminal result', async () => {
+    const yieldCount = 10_000;
+    const generatorTool = tool({
+      name: 'streaming_tool',
+      inputSchema: z.object({}),
+      eventSchema: z.object({
+        index: z.number(),
+      }),
+      outputSchema: z.object({
+        done: z.boolean(),
+      }),
+      execute: async function* () {
+        for (let index = 0; index < yieldCount; index += 1) {
+          yield {
+            index,
+          };
+        }
+        return {
+          done: true,
+        };
+      },
+    });
+    const toolCall: ParsedToolCall<Tool> = {
+      id: 'streaming-call',
+      name: 'streaming_tool',
+      arguments: {},
+    };
+    let broadcasts = 0;
+
+    const result = await executeGeneratorTool(generatorTool, toolCall, mockContext, () => {
+      broadcasts += 1;
+    });
+
+    expect(broadcasts).toBe(yieldCount);
+    expect(result.result).toEqual({
+      done: true,
+    });
+    expect(result.preliminaryResults).toBeUndefined();
+  });
+
   it('should capture return value even with no yields', async () => {
     const generatorTool = tool({
       name: 'return_only_tool',

--- a/packages/agent/tests/unit/tool-name-events.test.ts
+++ b/packages/agent/tests/unit/tool-name-events.test.ts
@@ -269,15 +269,8 @@ describe('toolName on runtime tool events', () => {
       result: {
         done: true,
       },
-      preliminaryResults: [
-        {
-          stage: 'one',
-        },
-        {
-          stage: 'two',
-        },
-      ],
     });
+    expect(finals[0]?.preliminaryResults).toBeUndefined();
 
     const legacyPrelims = legacyEvents.filter(
       (

--- a/packages/agent/tests/unit/tool-orchestrator.test.ts
+++ b/packages/agent/tests/unit/tool-orchestrator.test.ts
@@ -437,12 +437,8 @@ describe('executeToolLoop', () => {
       result: {
         done: true,
       },
-      preliminaryResults: [
-        {
-          pct: 50,
-        },
-      ],
     });
+    expect(result.toolExecutionResults[0]?.preliminaryResults).toBeUndefined();
   });
 
   it('applies nextTurnParams input changes to the conversation', async () => {
@@ -551,9 +547,6 @@ describe('toolResultsToMap', () => {
       makeResult({
         toolCallId: 'b',
         result: 2,
-        preliminaryResults: [
-          'p',
-        ],
       }),
     ];
 
@@ -561,13 +554,9 @@ describe('toolResultsToMap', () => {
 
     expect(map.get('a')).toEqual({
       result: 1,
-      preliminaryResults: undefined,
     });
     expect(map.get('b')).toEqual({
       result: 2,
-      preliminaryResults: [
-        'p',
-      ],
     });
     expect(map.size).toBe(2);
   });
@@ -587,10 +576,6 @@ describe('summarizeToolExecutions', () => {
       makeResult({
         toolName: 'chatty',
         toolCallId: 'b',
-        preliminaryResults: [
-          1,
-          2,
-        ],
       }),
       makeResult({
         toolName: 'bad',
@@ -603,7 +588,7 @@ describe('summarizeToolExecutions', () => {
     expect(summary).toBe(
       [
         '✅ good (a): SUCCESS',
-        '✅ chatty (b): SUCCESS (2 preliminary results)',
+        '✅ chatty (b): SUCCESS',
         '❌ bad (c): ERROR - nope',
       ].join('\n'),
     );


### PR DESCRIPTION
Fixes [DEV-817](https://linear.app/openrouter/issue/DEV-817/agent-sdk-090-patch-follow-ups-trim-unaware-stream-replays-executor).

Stop copying every generator-tool yield into a per-call array that lives until the call settles. Yields are still broadcast live via `onPreliminaryResult`; the terminal `tool.result` event no longer carries the full history.

This is the remaining isolate-memory landmine from the `@openrouter/agent` 0.9.0 review. [PR #109](https://github.com/OpenRouterTeam/typescript-agent/pull/109) already covers opt-in replay compaction. This PR covers executor / `ModelResult` accumulation.

## What

- `executeGeneratorTool` no longer pushes validated yields into `preliminaryResults`.
- `ModelResult` no longer accumulates `preliminaryResultsForCall` or attaches it to the terminal result event.
- `toolResultsToMap` / `summarizeToolExecutions` stop forwarding the unused array.
- Public types keep the optional field for compatibility; the runtime no longer populates it.

## Why

Fusion-style generator tools stream for minutes inside a 128MB Worker isolate. Broadcasting live is enough; retaining every yield until settle is O(total streamed bytes) and is the same failure mode the openrouter-web bun patch exists to stop.

The `getUsage()` / `getToolCalls()` trim-unaware replay half of DEV-817 is already handled by PR #109 (`initialResponse` cache + `getInitialResponse()`).

## Test plan

- [x] `pnpm lint` / `pnpm typecheck` in `packages/agent`
- [x] `pnpm test` in `packages/agent`: 96 files, 1153 tests
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->