### PR TITLE
feat(agent): add ./reusable-stream subpath export

### DIFF
--- a/.changeset/reusable-stream-subpath-export.md
+++ b/.changeset/reusable-stream-subpath-export.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/agent": patch
+---
+
+Add a `./reusable-stream` subpath export so consumers can import `ReusableReadableStream` directly (`@openrouter/agent/reusable-stream`) instead of going through the root barrel or patching the package. Mirrors the existing `./tool-event-broadcaster` entry; both replay classes are the units consumers need when asserting stream-retention behavior against the published package.

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -88,6 +88,10 @@
       "types": "./esm/lib/tool-event-broadcaster.d.ts",
       "default": "./esm/lib/tool-event-broadcaster.js"
     },
+    "./reusable-stream": {
+      "types": "./esm/lib/reusable-stream.d.ts",
+      "default": "./esm/lib/reusable-stream.js"
+    },
     "./turn-context": {
       "types": "./esm/lib/turn-context.d.ts",
       "default": "./esm/lib/turn-context.js"


### PR DESCRIPTION
Agent: focused follow-up completing the upstream replacement for [openrouter-web#33659](https://github.com/OpenRouterTeam/openrouter-web/pull/33659)'s bun patch.

## What

Adds a `./reusable-stream` export-map entry to `@openrouter/agent`, mirroring the existing `./tool-event-broadcaster` entry.

## Why

`ReusableReadableStream` is importable from source and heavily unit-tested, but the published package has no export entry for it. openrouter-web's 0.9.0 bump PR has to carry a `bun patch` hunk that adds exactly this entry so its `sdk-loop-memory-retention.test.ts` can do `import { ReusableReadableStream } from '@openrouter/agent/reusable-stream'`. With this entry upstream, that hunk — and with [#109](https://github.com/OpenRouterTeam/typescript-agent/pull/109) + [#110](https://github.com/OpenRouterTeam/typescript-agent/pull/110) + [#111](https://github.com/OpenRouterTeam/typescript-agent/pull/111) landed, the entire memory/startup patch — can be dropped.

## Verification

- `scripts/verify-package-boundaries.mjs` (packs real tarballs, installs into a scratch consumer, verifies every export target): passes
- Self-reference import resolves: `await import('@openrouter/agent/reusable-stream')` → `[ 'ReusableReadableStream' ]`
- `pnpm typecheck` / `pnpm lint` clean; `pnpm test`: 96 files, 1153 tests passing
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->