### PR TITLE
feat(agent): allow manual tools to supply a wire input schema

### DIFF
--- a/.changeset/bright-tools-wire-schema.md
+++ b/.changeset/bright-tools-wire-schema.md
@@ -1,0 +1,23 @@
+---
+'@openrouter/agent': minor
+---
+
+Allow manual tools to provide a caller-owned JSON Schema for wire serialization.
+
+```ts
+import { tool } from '@openrouter/agent';
+import { z } from 'zod';
+
+const confirmTool = tool({
+  name: 'confirm_action',
+  inputSchema: z.object({ action: z.string() }),
+  wireInputSchema: {
+    type: 'object',
+    properties: {
+      action: { type: 'string' },
+    },
+    required: ['action'],
+  },
+  execute: false,
+});
+```

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -221,6 +221,14 @@ const analysisTool = tool({
 const confirmTool = tool({
   name: 'confirm_action',
   inputSchema: z.object({ action: z.string() }),
+  // Forward an existing JSON Schema without converting it through Zod.
+  wireInputSchema: {
+    type: 'object',
+    properties: {
+      action: { type: 'string' },
+    },
+    required: ['action'],
+  },
   execute: false,
 });
 ```

--- a/packages/agent/src/lib/tool-executor.ts
+++ b/packages/agent/src/lib/tool-executor.ts
@@ -22,6 +22,7 @@ import {
   isDeferredHandle,
   isGeneratorTool,
   isHITLTool,
+  isManualTool,
   isMcpTool,
   isRegularExecuteTool,
   isServerTool,
@@ -129,7 +130,10 @@ export function convertToolsToAPIFormat(
       name: tool.function.name,
       description: tool.function.description || null,
       strict: tool.function.strict ?? null,
-      parameters: convertZodToJsonSchema(tool.function.inputSchema),
+      parameters:
+        isManualTool(tool) && tool.function.wireInputSchema !== undefined
+          ? sanitizeJsonSchema(tool.function.wireInputSchema)
+          : convertZodToJsonSchema(tool.function.inputSchema),
     };
     return apiTool;
   });

--- a/packages/agent/src/lib/tool-types.ts
+++ b/packages/agent/src/lib/tool-types.ts
@@ -575,6 +575,15 @@ export interface ManualToolFunction<
   TCtx extends $ZodObject<$ZodShape> = $ZodObject<$ZodShape>,
   TName extends string = string,
 > extends BaseToolFunction<TInput, TCtx, TName> {
+  /**
+   * JSON Schema to serialize for this tool instead of regenerating one from
+   * `inputSchema`. Manual tools are never executed or input-validated by the
+   * SDK, so a caller that already owns a JSON Schema can forward it verbatim
+   * (sanitized of `~`-prefixed metadata keys) and skip the round trip through
+   * Zod, which both costs CPU/allocations and cannot represent constructs like
+   * `anyOf` / `oneOf`.
+   */
+  readonly wireInputSchema?: Readonly<Record<string, unknown>>;
   outputSchema?: TOutput;
 }
 

--- a/packages/agent/src/lib/tool.ts
+++ b/packages/agent/src/lib/tool.ts
@@ -150,6 +150,8 @@ type ManualToolConfig<
   name: TName;
   description?: string;
   inputSchema: TInput;
+  /** JSON Schema to serialize instead of regenerating `inputSchema`; manual tools only. */
+  readonly wireInputSchema?: Readonly<Record<string, unknown>>;
   /** Strict schema adherence for tool-call generation — see {@link BaseToolFunction.strict} */
   strict?: boolean | null;
   /** Zod schema declaring the context data this tool needs */
@@ -243,19 +245,27 @@ type ToolConfigWithSharedContext<
   timeoutMs?: number;
   /** Max simultaneous in-flight executions of this tool across the run */
   maxConcurrency?: number;
-  execute:
-    | ((
-        params: Record<string, unknown>,
-        context?: ToolExecuteContext<TName, ContextFromSchema<TCtx>, TShared>,
-      ) => unknown)
-    | ((
-        params: Record<string, unknown>,
-        context?: ToolExecuteContext<TName, ContextFromSchema<TCtx>, TShared>,
-      ) => AsyncGenerator<unknown>)
-    | false;
   /** Convert tool execution output to model-facing output */
   toModelOutput?: ToModelOutputFunction<Record<string, unknown>, unknown>;
-};
+} & (
+  | {
+      execute: false;
+      /** JSON Schema to serialize instead of regenerating `inputSchema`; manual tools only. */
+      readonly wireInputSchema?: Readonly<Record<string, unknown>>;
+    }
+  | {
+      execute:
+        | ((
+            params: Record<string, unknown>,
+            context?: ToolExecuteContext<TName, ContextFromSchema<TCtx>, TShared>,
+          ) => unknown)
+        | ((
+            params: Record<string, unknown>,
+            context?: ToolExecuteContext<TName, ContextFromSchema<TCtx>, TShared>,
+          ) => AsyncGenerator<unknown>);
+      readonly wireInputSchema?: never;
+    }
+);
 
 /**
  * Shared fields for unified `run` tool configs.
@@ -672,6 +682,14 @@ export function tool(
 
     if (config.strict !== undefined) {
       fn.strict = config.strict;
+    }
+
+    if ('wireInputSchema' in config && config.wireInputSchema !== undefined) {
+      (
+        fn as {
+          wireInputSchema?: unknown;
+        }
+      ).wireInputSchema = config.wireInputSchema;
     }
 
     return {

--- a/packages/agent/tests/unit/manual-tool-wire-schema.test-d.ts
+++ b/packages/agent/tests/unit/manual-tool-wire-schema.test-d.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod/v4';
+import { tool } from '../../src/lib/tool.js';
+
+const manualTool = tool({
+  name: 'manual_wire_schema',
+  inputSchema: z.object({
+    value: z.string(),
+  }),
+  wireInputSchema: {
+    type: 'object',
+    properties: {
+      value: {
+        type: 'string',
+      },
+    },
+  },
+  execute: false,
+});
+void manualTool;
+
+// @ts-expect-error wireInputSchema is only accepted for manual tools
+tool({
+  name: 'executable_wire_schema',
+  inputSchema: z.object({
+    value: z.string(),
+  }),
+  execute: () => 'done',
+  wireInputSchema: {
+    type: 'object',
+  },
+});

--- a/packages/agent/tests/unit/manual-tool-wire-schema.test.ts
+++ b/packages/agent/tests/unit/manual-tool-wire-schema.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { tool } from '../../src/lib/tool.js';
+import { convertToolsToAPIFormat } from '../../src/lib/tool-executor.js';
+
+describe('manual tool wireInputSchema', () => {
+  it('serializes anyOf and oneOf while sanitizing tilde-prefixed keys', () => {
+    const wireInputSchema = {
+      type: 'object',
+      '~rootMetadata': 'remove me',
+      properties: {
+        choice: {
+          '~propertyMetadata': 'remove me',
+          anyOf: [
+            {
+              type: 'string',
+            },
+            {
+              type: 'number',
+            },
+          ],
+          oneOf: [
+            {
+              const: 'first',
+            },
+            {
+              const: 'second',
+            },
+          ],
+        },
+      },
+      required: [
+        'choice',
+      ],
+    };
+
+    const manualTool = tool({
+      name: 'choose_value',
+      description: 'Choose a value',
+      inputSchema: z.object({
+        choice: z.string(),
+      }),
+      wireInputSchema,
+      execute: false,
+      strict: true,
+    });
+    const api = convertToolsToAPIFormat([
+      manualTool,
+    ]);
+    const emitted = api[0];
+    const parameters = 'parameters' in emitted ? emitted.parameters : undefined;
+
+    expect(emitted).toMatchObject({
+      type: 'function',
+      name: 'choose_value',
+      description: 'Choose a value',
+      strict: true,
+    });
+    expect(parameters).toEqual({
+      type: 'object',
+      properties: {
+        choice: {
+          anyOf: [
+            {
+              type: 'string',
+            },
+            {
+              type: 'number',
+            },
+          ],
+          oneOf: [
+            {
+              const: 'first',
+            },
+            {
+              const: 'second',
+            },
+          ],
+        },
+      },
+      required: [
+        'choice',
+      ],
+    });
+  });
+
+  it('does not mutate the caller-owned schema and emits a copy', () => {
+    const wireInputSchema = {
+      type: 'object',
+      '~rootMetadata': true,
+      properties: {
+        value: {
+          type: 'string',
+          '~nestedMetadata': true,
+        },
+      },
+    };
+    const originalSchema = structuredClone(wireInputSchema);
+    const manualTool = tool({
+      name: 'copy_schema',
+      inputSchema: z.object({
+        value: z.string(),
+      }),
+      wireInputSchema,
+      execute: false,
+    });
+
+    const api = convertToolsToAPIFormat([
+      manualTool,
+    ]);
+    const emitted = api[0];
+    const parameters = 'parameters' in emitted ? emitted.parameters : undefined;
+
+    expect(wireInputSchema).toEqual(originalSchema);
+    expect(parameters).not.toBe(wireInputSchema);
+  });
+
+  it('falls back to the Zod-derived schema without wireInputSchema', () => {
+    const manualTool = tool({
+      name: 'fallback_schema',
+      inputSchema: z.object({
+        value: z.string(),
+      }),
+      execute: false,
+    });
+
+    const api = convertToolsToAPIFormat([
+      manualTool,
+    ]);
+    const emitted = api[0];
+    const parameters = 'parameters' in emitted ? emitted.parameters : undefined;
+
+    expect(parameters).toMatchObject({
+      type: 'object',
+      properties: {
+        value: {
+          type: 'string',
+        },
+      },
+    });
+  });
+
+  it('uses the Zod-derived schema for executable shared-context tools', () => {
+    const executableTool = tool<{
+      sessionId: string;
+    }>()({
+      name: 'shared_context_tool',
+      inputSchema: z.object({
+        count: z.number(),
+      }),
+      execute: (params, context) => {
+        context?.shared.sessionId;
+        return params.count;
+      },
+    });
+
+    const api = convertToolsToAPIFormat([
+      executableTool,
+    ]);
+    const emitted = api[0];
+    const parameters = 'parameters' in emitted ? emitted.parameters : undefined;
+
+    expect(parameters).toMatchObject({
+      type: 'object',
+      properties: {
+        count: {
+          type: 'number',
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Manual tools (`execute: false`) may now carry a caller-owned JSON Schema in `wireInputSchema`, which `convertToolsToAPIFormat` serializes instead of regenerating one from `inputSchema`.

The SDK never executes or input-validates a manual tool, so the Zod schema on such a tool exists only to be converted back to JSON Schema at serialization time. A caller that already holds the JSON Schema therefore pays a full round trip for nothing:

```
caller JSON Schema → Zod graph → z.toJSONSchema() → wire
```

That round trip is not free and not lossless. It allocates a Zod object graph per tool per request, and constructs Zod cannot represent (`anyOf`, `oneOf`) degrade on the way through. `wireInputSchema` short-circuits it:

```diff
-      parameters: convertZodToJsonSchema(tool.function.inputSchema),
+      parameters:
+        isManualTool(tool) && tool.function.wireInputSchema !== undefined
+          ? sanitizeJsonSchema(tool.function.wireInputSchema)
+          : convertZodToJsonSchema(tool.function.inputSchema),
```

`sanitizeJsonSchema` still runs, so `~`-prefixed Standard Schema metadata never reaches a provider, and because it deep-copies, the caller's schema object is not mutated.

The knob is gated to manual tools on both sides. At runtime `isManualTool` excludes HITL (`onToolCalled`), unified (`run`), generator, regular and server tools, so every other path keeps its exact current behavior. At the type level `ToolConfigWithSharedContext` becomes an intersection with a two-branch union, so the field is available with `execute: false` and `never` with an `execute` function:

```ts
} & (
  | { execute: false; readonly wireInputSchema?: Readonly<Record<string, unknown>> }
  | { execute: (…) => unknown | (…) => AsyncGenerator<unknown>; readonly wireInputSchema?: never }
);
```

Motivation is a hot path in `openrouter-web`: the server-tools plugin rebuilt a Zod schema from each caller-supplied function tool on every request purely so the SDK could serialize it back, and it currently carries this behavior as a local patch against `@openrouter/agent@0.10.0` ([openrouter-web#36877](https://github.com/OpenRouterTeam/openrouter-web/pull/36877), [openrouter-web#36878](https://github.com/OpenRouterTeam/openrouter-web/pull/36878)). Upstreaming it lets that patch hunk be deleted at the next version bump. The win generalizes to any caller whose tool schemas originate as JSON Schema (proxies, MCP bridges, anything forwarding a downstream client's `tools` array).

### API example

```ts
import { tool } from '@openrouter/agent';
import { z } from 'zod';

const confirmTool = tool({
  name: 'confirm_action',
  // still required, still the source of truth for types; never used on the wire here
  inputSchema: z.object({ action: z.string() }),
  // new: serialized verbatim (minus `~`-prefixed keys) instead of re-deriving
  // JSON Schema from `inputSchema`
  wireInputSchema: {
    type: 'object',
    properties: { action: { type: 'string' } },
    required: ['action'],
  },
  execute: false,
});
```

Additive and optional: a manual tool without `wireInputSchema` serializes exactly as before.

## Tests

`packages/agent/tests/unit/manual-tool-wire-schema.test.ts` asserts against `convertToolsToAPIFormat` output — `anyOf`/`oneOf` survive, `~` keys are stripped at the root and nested under `properties`, the caller's object is neither mutated nor emitted by reference, a manual tool without the field still gets the Zod-derived schema, and an executable shared-context tool is unaffected. `manual-tool-wire-schema.test-d.ts` pins the type-level gate (accepted with `execute: false`, `@ts-expect-error` alongside an `execute` function).

`pnpm run lint`, `pnpm run typecheck`, and `pnpm --filter @openrouter/agent test` (104 files, 1221 tests, no type errors) pass locally.


Link to Devin session: https://openrouter.devinenterprise.com/sessions/acb44a847f1c4670b21a50fdfae26ef0
Requested by: @sambarnes
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->