### PR TITLE
feat(agent): identify Agent SDK traffic in the user agent

### DIFF
--- a/.changeset/tidy-agents-smile.md
+++ b/.changeset/tidy-agents-smile.md
@@ -1,0 +1,13 @@
+---
+'@openrouter/agent': patch
+---
+
+Identify Agent SDK requests with an Agent SDK user-agent suffix that includes the package version.
+
+```ts
+import { OpenRouter } from '@openrouter/agent';
+
+const client = new OpenRouter({ apiKey: process.env.OPENROUTER_API_KEY });
+// Requests use the Agent SDK user agent by default.
+// Pass userAgent to override the default identification.
+```

--- a/packages/agent/src/lib/user-agent.ts
+++ b/packages/agent/src/lib/user-agent.ts
@@ -1,0 +1,6 @@
+import { SDK_METADATA } from '@openrouter/sdk/lib/config';
+
+import { PACKAGE_VERSION } from '../mcp/version.js';
+
+/** Keeps the base Speakeasy string byte-identical and appends one token for openrouter-web analytics. */
+export const AGENT_USER_AGENT = `${SDK_METADATA.userAgent} @openrouter/agent/${PACKAGE_VERSION}`;

--- a/packages/agent/src/openrouter.ts
+++ b/packages/agent/src/openrouter.ts
@@ -15,6 +15,7 @@ import { callModel } from './inner-loop/call-model.js';
 import type { CallModelInput } from './lib/async-params.js';
 import type { ModelResult } from './lib/model-result.js';
 import type { Tool } from './lib/tool-types.js';
+import { AGENT_USER_AGENT } from './lib/user-agent.js';
 
 export type { SDKOptions } from '@openrouter/sdk/lib/config';
 
@@ -74,13 +75,15 @@ export class OpenRouter extends OpenRouterCore {
   constructor(options?: OpenRouterOptions) {
     const { hooks: hooksInput, ...rest } = options ?? {};
     const hooks = buildSDKHooks(hooksInput);
-    super(
-      hooks === undefined
-        ? rest
-        : Object.assign({}, rest, {
+    super({
+      ...rest,
+      userAgent: rest.userAgent ?? AGENT_USER_AGENT,
+      ...(hooks === undefined
+        ? {}
+        : {
             hooks,
           }),
-    );
+    });
   }
 
   callModel = <

--- a/packages/agent/tests/unit/openrouter.test.ts
+++ b/packages/agent/tests/unit/openrouter.test.ts
@@ -5,8 +5,10 @@ import type {
   BeforeRequestContext,
   BeforeRequestHook,
 } from '@openrouter/sdk/hooks/types';
+import { HTTPClient } from '@openrouter/sdk/lib/http';
 import { describe, expect, it } from 'vitest';
 import { ModelResult } from '../../src/lib/model-result.js';
+import { AGENT_USER_AGENT } from '../../src/lib/user-agent.js';
 import { OpenRouter } from '../../src/openrouter.js';
 
 describe('OpenRouter', () => {
@@ -51,6 +53,45 @@ describe('OpenRouter', () => {
       serverURL: 'https://custom.endpoint.com',
     });
     expect(openrouter).toBeInstanceOf(OpenRouter);
+  });
+
+  it('should default to the Agent SDK user agent', () => {
+    const openrouter = new OpenRouter({
+      apiKey: 'test-key',
+    });
+    expect(openrouter._options.userAgent).toBe(AGENT_USER_AGENT);
+  });
+
+  it('should preserve an explicitly configured user agent', () => {
+    const openrouter = new OpenRouter({
+      apiKey: 'test-key',
+      userAgent: 'custom/1.0',
+    });
+    expect(openrouter._options.userAgent).toBe('custom/1.0');
+  });
+
+  it('should send the Agent SDK user agent on outgoing requests', async () => {
+    let capturedUserAgent: string | null = null;
+    const httpClient = new HTTPClient();
+    httpClient.request = async (request: Request): Promise<Response> => {
+      capturedUserAgent = request.headers.get('user-agent');
+      throw new Error('captured request');
+    };
+
+    const openrouter = new OpenRouter({
+      apiKey: 'test-key',
+      httpClient,
+    });
+
+    await expect(
+      openrouter
+        .callModel({
+          model: 'openai/gpt-4o',
+          input: 'Hello',
+        })
+        .getText(),
+    ).rejects.toThrow('captured request');
+    expect(capturedUserAgent).toBe(AGENT_USER_AGENT);
   });
 
   it('should be an instance of OpenRouterCore', () => {
@@ -113,11 +154,13 @@ describe('OpenRouter', () => {
     it('should wrap a single hook object into an SDKHooks instance', () => {
       const openrouter = new OpenRouter({
         apiKey: 'test-key',
+        userAgent: 'custom/1.0',
         hooks: noopBeforeRequest,
       });
       expect(openrouter._options.hooks).toBeInstanceOf(SDKHooks);
       expect(openrouter._options.hooks?.beforeRequestHooks).toHaveLength(1);
       expect(openrouter._options.hooks?.beforeRequestHooks[0]).toBe(noopBeforeRequest);
+      expect(openrouter._options.userAgent).toBe('custom/1.0');
     });
 
     it('should wrap an array of hook objects into an SDKHooks instance', () => {

--- a/packages/agent/tests/unit/user-agent.test.ts
+++ b/packages/agent/tests/unit/user-agent.test.ts
@@ -1,0 +1,12 @@
+import { SDK_METADATA } from '@openrouter/sdk/lib/config';
+import { describe, expect, it } from 'vitest';
+import { AGENT_USER_AGENT } from '../../src/lib/user-agent.js';
+import { PACKAGE_VERSION } from '../../src/mcp/version.js';
+
+describe('AGENT_USER_AGENT', () => {
+  it('composes the SDK and Agent package versions', () => {
+    expect(AGENT_USER_AGENT).toBe(`${SDK_METADATA.userAgent} @openrouter/agent/${PACKAGE_VERSION}`);
+    expect(AGENT_USER_AGENT.startsWith('speakeasy-sdk/typescript ')).toBe(true);
+    expect(AGENT_USER_AGENT).toMatch(/ @openrouter\/agent\/\d+\.\d+\.\d+$/u);
+  });
+});


### PR DESCRIPTION
## Summary

`@openrouter/agent` now identifies itself in the `user-agent` header, so OpenRouter can attribute traffic to the Agent SDK and to a specific agent package version instead of inferring it. Today an agent request is indistinguishable on the wire from a direct `@openrouter/sdk` request, apart from the `x-openrouter-callmodel` marker that only `callModel` sends.

The `OpenRouter` client defaults `SDKOptions.userAgent`, and an explicit caller value still wins:

```ts
super({ ...rest, userAgent: rest.userAgent ?? AGENT_USER_AGENT, ...hooks })
```

`AGENT_USER_AGENT` appends one conventional `product/version` token to the generated Speakeasy string, keeping the base byte-identical so anything already parsing it keeps working:

```text
speakeasy-sdk/typescript 0.13.7 2.884.4 1.0.0 @openrouter/sdk @openrouter/agent/0.11.0
```

Both halves are composed at runtime from `SDK_METADATA.userAgent` and the generated `PACKAGE_VERSION`, so a dependency bump or a release moves them without another edit here.

Two design points worth stating, both of which are why the `x-openrouter-callmodel` header stays exactly as it was:

1. The header is the only signal that survives browsers. `@openrouter/sdk` skips the user agent entirely under `if (!isBrowserLike)`, because CORS forbids setting it.
2. Construction is the only override point. The SDK sets the user agent after merging caller-supplied `options.headers`, reading `client._options.userAgent` per operation, so a per-request header cannot win. `callModel` also accepts any `OpenRouterCore`, and a caller who passes a plain SDK client is deliberately left alone rather than having their client's options mutated.

The matching analytics side is [openrouter-web#37298](https://github.com/OpenRouterTeam/openrouter-web/pull/37298), which parses this string into `sdk_client`, `sdk_package`, `sdk_version` and the agent version on generations.

## How I verified

- `pnpm run lint`, `pnpm run typecheck`, `pnpm run build`, `pnpm run test` and `pnpm run verify:packages` all pass. Full agent suite is 103 files and 1222 tests.
- A wire-level unit test asserts the header on the outgoing request rather than the option value, by capturing the `Request` through an injected `httpClient`. That is the test that fails if the SDK ever changes its override order:

```ts
httpClient.request = async (request) => {
  capturedUserAgent = request.headers.get('user-agent');
  throw new Error('captured request');
};
// ...
expect(capturedUserAgent).toBe(AGENT_USER_AGENT);
```

- The composition test pins the format that openrouter-web parses, asserting the `speakeasy-sdk/typescript ` prefix and a trailing `@openrouter/agent/<semver>` token, so a reformat of the string breaks the test here rather than silently dropping attribution in production.
- `pnpm run test:e2e` was not run, it requires a live `OPENROUTER_API_KEY`.


Link to Devin session: https://openrouter.devinenterprise.com/sessions/4694f6390dd142739b1941b796452585
Requested by: @LukasParke
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/typescript-agent/pull/120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->