### PR TITLE
fix(agent): prevent unhandled rejection when aborting stream

### DIFF
--- a/.changeset/unhandled-rejection-stream-abort.md
+++ b/.changeset/unhandled-rejection-stream-abort.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/agent': patch
+---
+
+Prevent unhandled promise rejection crash when aborting a tool-enabled stream.

--- a/packages/agent/src/lib/model-result.ts
+++ b/packages/agent/src/lib/model-result.ts
@@ -1098,6 +1098,9 @@ export class ModelResult<
       }
       broadcaster.complete();
     });
+    // Attach an immediate rejection handler so early consumer exit (such as an abort)
+    // does not leave executionPromise as an unhandled promise rejection.
+    void executionPromise.catch(() => {});
     return {
       consumer,
       executionPromise,

--- a/packages/agent/tests/unit/run-cancellation.test.ts
+++ b/packages/agent/tests/unit/run-cancellation.test.ts
@@ -389,4 +389,64 @@ describe('per-request timeoutMs composition', () => {
     expect(text).toBe('done');
     expect(mockBetaResponsesSend).toHaveBeenCalledTimes(2);
   });
+
+  it('does not emit unhandledRejection when aborting a tool-enabled stream', async () => {
+    const unhandledRejections: unknown[] = [];
+    const onUnhandled = (err: unknown) => {
+      unhandledRejections.push(err);
+    };
+    process.on('unhandledRejection', onUnhandled);
+
+    try {
+      const controller = new AbortController();
+      let streamController!: ReadableStreamDefaultController<models.StreamEvents>;
+      const stream = new ReadableStream<models.StreamEvents>({
+        start(c) {
+          streamController = c;
+        },
+      });
+
+      mockBetaResponsesSend.mockImplementation(async (_client, _req, options) => {
+        options.signal?.addEventListener('abort', () => {
+          streamController.error(options.signal?.reason ?? new Error('Aborted'));
+        });
+        return {
+          ok: true,
+          value: stream,
+        };
+      });
+
+      const result = callModel(client, {
+        model: 'test-model',
+        input: 'hello',
+        tools: [
+          echoTool,
+        ],
+        signal: controller.signal,
+      });
+
+      let streamError: unknown;
+      try {
+        streamController.enqueue({
+          type: 'response.output_text.delta',
+          delta: 'chunk',
+          sequenceNumber: 0,
+        } as models.StreamEvents);
+
+        for await (const _event of result.getFullResponsesStream()) {
+          controller.abort(new DOMException('This operation was aborted', 'AbortError'));
+        }
+      } catch (err) {
+        streamError = err;
+      }
+
+      expect(streamError).toBeDefined();
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(unhandledRejections).toHaveLength(0);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
 });


### PR DESCRIPTION
Fixes #113

### Summary of Changes
- Attached a no-op rejection handler to `executionPromise` inside `startTurnBroadcasterExecution()` in [`packages/agent/src/lib/model-result.ts`](file:///packages/agent/src/lib/model-result.ts). This ensures that when a stream consumer aborts or terminates iteration early, the background promise rejection does not trigger an `unhandledRejection` event.
- Added regression unit test in [`packages/agent/tests/unit/run-cancellation.test.ts`](file:///packages/agent/tests/unit/run-cancellation.test.ts).
- Added changeset file for `@openrouter/agent` (patch).